### PR TITLE
Fix: separator가 윈도우만 호환

### DIFF
--- a/Assets/Scripts/Utils/LogEx.cs
+++ b/Assets/Scripts/Utils/LogEx.cs
@@ -162,7 +162,7 @@ namespace Cardevil.Utils
                 line = Convert.ToInt32(pathline.Substring(split_index + 1));
                 string fullpath = Application.dataPath.Substring(0, Application.dataPath.LastIndexOf("Assets"));
                 fullpath = fullpath + path;
-                string strPath = fullpath.Replace('/', '\\');
+                string strPath = System.IO.Path.DirectorySeparatorChar == '\\' ? fullpath.Replace('/', '\\') : fullpath.Replace('\\', '/');
                 UnityEditorInternal.InternalEditorUtility.OpenFileAtLineExternal(strPath, line);
             }
             return true;


### PR DESCRIPTION
```C#
string strPath = fullpath.Replace('/', '\\');
```
OnOpenAsset에서 경로를 OS별 구분자(\\//)에 맞게 정리하도록 수정했습니다.
맥 환경에서 잘못된 빈 파일이 열리던 문제를 해결했습니다.