### PR TITLE
FEAT : 콘솔 자동완성

### DIFF
--- a/Assets/Prefabs/UI/ConsoleUI.prefab
+++ b/Assets/Prefabs/UI/ConsoleUI.prefab
@@ -48,7 +48,7 @@ MonoBehaviour:
   consolePanel: {fileID: 5747942972999059705}
   _isInitialized: 0
   _isOpen: 0
-  _useAutoComplete: 0
+  _useAutoComplete: 1
   _toggleConsoleAction:
     m_Name: Toggle Console
     m_Type: 0

--- a/Assets/Scenes/ConsoleTestScnene.unity
+++ b/Assets/Scenes/ConsoleTestScnene.unity
@@ -2244,6 +2244,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2613411705685657411, guid: 93d3f4657318363438a75c0a2852265f, type: 3}
+      propertyPath: _useAutoComplete
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5160266128926049352, guid: 93d3f4657318363438a75c0a2852265f, type: 3}
       propertyPath: m_LocalPosition.x
       value: 6.152964

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2633,10 +2633,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 2613411705685657411, guid: 93d3f4657318363438a75c0a2852265f, type: 3}
-      propertyPath: _autoCompleteConsoleAction.m_Name
-      value: Auto Complete Console
-      objectReference: {fileID: 0}
     - target: {fileID: 5160266128926049352, guid: 93d3f4657318363438a75c0a2852265f, type: 3}
       propertyPath: m_LocalPosition.x
       value: -951.925
@@ -2680,10 +2676,6 @@ PrefabInstance:
     - target: {fileID: 5747942972999059705, guid: 93d3f4657318363438a75c0a2852265f, type: 3}
       propertyPath: m_Name
       value: ConsoleUI
-      objectReference: {fileID: 0}
-    - target: {fileID: 8934324070627063684, guid: 93d3f4657318363438a75c0a2852265f, type: 3}
-      propertyPath: m_Enabled
-      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/DebugConsole/AutoCompleter.cs
+++ b/Assets/Scripts/DebugConsole/AutoCompleter.cs
@@ -1,0 +1,122 @@
+﻿using Cardevil.DebugConsole.Commands;
+using System.Collections.Generic;
+
+namespace Cardevil.DebugConsole
+{
+    public class AutoCompleter 
+    {
+        private string _chachedInput = "";
+        private List<string> _cachedSuggestions = new List<string>();
+        private int _currentIndex = -1;
+        
+        public string ChachedInput => _chachedInput;
+        public string CurrentSuggestion => GetCurrentSuggestion();
+        public IReadOnlyList<string> CurrentSuggestions => _cachedSuggestions.AsReadOnly();
+        public int CurrentIndex => _currentIndex;
+        public int SuggestionCount => _cachedSuggestions.Count;
+        public bool HasSuggestions => _cachedSuggestions.Count > 0;
+        
+        public AutoCompleter()
+        {
+            
+        }
+        
+        public void Clear()
+        {
+            _chachedInput = "";
+            _cachedSuggestions.Clear();
+            _currentIndex = -1;
+        }
+        
+        public void TextInputChanged(string input)
+        {
+            if (input != _chachedInput)
+            {
+                _chachedInput = input;
+                _cachedSuggestions = GetSuggestions(input);
+                _currentIndex = -1;
+            }
+        }
+        public string GetCurrentSuggestion()
+        {
+            if (_currentIndex < 0 || _currentIndex >= _cachedSuggestions.Count)
+                return null;
+            return _cachedSuggestions[_currentIndex];
+        }
+        public string GetNextSuggestion()
+        {
+            if (_cachedSuggestions.Count == 0)
+                return null;
+            _currentIndex = (_currentIndex + 1) % _cachedSuggestions.Count;
+            return _cachedSuggestions[_currentIndex];
+        }
+        public string GetPreviousSuggestion()
+        {
+            if (_cachedSuggestions.Count == 0)
+                return null;
+            _currentIndex = (_currentIndex - 1 + _cachedSuggestions.Count) % _cachedSuggestions.Count;
+            return _cachedSuggestions[_currentIndex];
+        }
+        
+        public bool SetCurrentIndex(int index)
+        {
+            if (index < 0 || index >= _cachedSuggestions.Count)
+                return false;
+            _currentIndex = index;
+            return true;
+        }
+
+        public bool SetCurrentSuggestion(string suggestion)
+        {
+            int index = _cachedSuggestions.IndexOf(suggestion);
+            if (index == -1)
+                return false;
+            _currentIndex = index;
+            return true;
+        }
+        
+        public IReadOnlyList<string> GetAllSuggestions()
+        {
+            return _cachedSuggestions.AsReadOnly();
+        }
+        
+        public List<string> GetSuggestions(string input)
+        {
+            // TODO : 배열 복사가 빈번하게 일어남
+            List<string> suggestions = new List<string>();
+            string[] parts = input.Split(' ');
+            if (parts.Length == 0)
+                return suggestions;
+            string commandPart = parts[0];
+            string[] argsPart = new string[parts.Length - 1];
+            for (int i = 1; i < parts.Length; i++)
+                argsPart[i - 1] = parts[i];
+            
+            int completTarget = argsPart.Length;
+
+            // 명령어부분
+            if (completTarget == 0)
+            {
+                foreach (var cmd in CommandLibrary.GetAllCommands())
+                {
+                    if (cmd.Command.StartsWith(commandPart))
+                    {
+                        suggestions.Add(cmd.Command);
+                    }
+                }
+                return suggestions;
+            }
+            
+            // 인자부분
+            foreach (var cmd in CommandLibrary.GetAllCommands())
+            {
+                if (cmd.Command.StartsWith(commandPart))
+                {
+                    cmd.AutoComplete(argsPart, ref suggestions);
+                }
+            }
+            return suggestions;
+        }
+        
+    }
+}

--- a/Assets/Scripts/DebugConsole/AutoCompleter.cs.meta
+++ b/Assets/Scripts/DebugConsole/AutoCompleter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7c47848386e1404db100e8f44543e82d
+timeCreated: 1759759872

--- a/Assets/Scripts/DebugConsole/ConsoleUI.cs
+++ b/Assets/Scripts/DebugConsole/ConsoleUI.cs
@@ -45,7 +45,7 @@ namespace Cardevil.DebugConsole
         private VisualElement root = null;
         TextField textField = null;
         
-        VisualElement previewContainer = null;
+        ScrollView previewContainer = null;
         ScrollView historyContainer = null;
         
         /*
@@ -57,16 +57,15 @@ namespace Cardevil.DebugConsole
         /*
          * 자동완성 관련
          */
-        private string _cachedAutoCompleteInput = "";
-        private bool _isAutoCompleteRequested = false;
+        [Header("자동완성 관련")]
+        private AutoCompleter _autoCompleter = new AutoCompleter();
         /// <summary>
         /// 해당 텍스트 변경이 자동완성 요청에 의한 것인지 여부.
         /// </summary>
         private bool _wasAutoCompleteJustRequested = false;
-        private int _autoCompleteIndex = 0;
-        private List<string> _suggestions = new List<string>();
-
-
+        private List<string> _submittedCommands = new List<string>();
+        private int _currentRecallIndex = -1;
+        public IReadOnlyList<string> SubmittedCommands => _submittedCommands.AsReadOnly();
         
         private void Reset()
         {
@@ -121,7 +120,7 @@ namespace Cardevil.DebugConsole
             
             
             textField = trueRoot.Q<TextField>("InputField");
-            previewContainer = trueRoot.Q<VisualElement>("PreviewContainer");
+            previewContainer = trueRoot.Q<ScrollView>("PreviewContainer");
             historyContainer = trueRoot.Q<ScrollView>("HistoryContainer");
             historyContainer.AddToClassList("history");
             
@@ -236,11 +235,12 @@ namespace Cardevil.DebugConsole
             textField.value = "";
 
             ScrollToBottom();
-            
-            UniTask.DelayFrame(1).ContinueWith(() =>
+
+            textField.schedule.Execute(() =>
             {
                 if (!IsOpen) return;
                 textField.Focus();
+                OnTextChanged(textField.value);
             });
         }
 
@@ -267,6 +267,21 @@ namespace Cardevil.DebugConsole
             label.AddToClassList("log-line");
             label.AddToClassList("message");
             label.AddToClassList(type.UssTag);
+            historyContainer.Add(label);
+            historyContainer.ScrollTo(label);
+        }
+        
+        private void Message(MessageType type, string message, params string[] additionalClasses)
+        {
+            var label = new Label(message);
+            label.AddToClassList("log-line");
+            label.AddToClassList("message");
+            label.AddToClassList(type.UssTag);
+            foreach (var cls in additionalClasses)
+            {
+                label.AddToClassList(cls);
+            }
+            
             historyContainer.Add(label);
             historyContainer.ScrollTo(label);
         }
@@ -335,53 +350,33 @@ namespace Cardevil.DebugConsole
         /// <param name="input"></param>
         public void RequestAutoComplete(string input)
         {
-            if (_isAutoCompleteRequested)
+            if(!_useAutoComplete)
+                return;
+            if (_autoCompleter.SuggestionCount == 0)
             {
-                // 기존 제안이 있는 경우
-                if (_suggestions.Count == 0) return;
-                _autoCompleteIndex = (_autoCompleteIndex + 1) % _suggestions.Count;
-                _wasAutoCompleteJustRequested = true;
-                var previewLabels = previewContainer.Query<Label>().ToList();
-                for (int i = 0; i < previewLabels.Count; i++)
+                _autoCompleter.TextInputChanged(input);
+                if (_autoCompleter.SuggestionCount == 0)
                 {
-                    if (i == _autoCompleteIndex)
-                    {
-                        previewLabels[i].AddToClassList("selected");
-                    }
-                    else
-                    {
-                        previewLabels[i].RemoveFromClassList("selected");
-                    }
+                    // 제안 없음
+                    previewContainer.Clear();
+                    return;
                 }
-                SetInputField(_suggestions[_autoCompleteIndex]);
-                textField.Focus();
+            }
+            string suggestion = _autoCompleter.GetNextSuggestion();
+            if (suggestion != null)
+            {
+                _wasAutoCompleteJustRequested = true;
+                SetInputField(suggestion);
+                UpdatePreviewContainer();
             }
             else
             {
-                // 새로운 자동완성 요청
-                _isAutoCompleteRequested = true;
-                _autoCompleteIndex = 0;
-                _suggestions.Clear();
-                var args = input.Split(' ');
-                Console.GetAutoCompleteSuggestions(args, ref _suggestions);
+                previewContainer.Clear();
             }
+            textField.cursorIndex = textField.value.Length;
+            textField.selectIndex = textField.value.Length;
         }
 
-        /// <summary>
-        /// 자동완성 제안을 갱신합니다.
-        /// </summary>
-        public void RefreshAutoCompleteSuggestions()
-        {
-            previewContainer.Clear();
-            if (_suggestions.Count == 0) return;
-            Console.GetAutoCompleteSuggestions(_cachedAutoCompleteInput.Split(' '), ref _suggestions);
-            foreach (var suggestion in _suggestions)
-            {
-                var label = new Label(suggestion);
-                label.AddToClassList("suggestion");
-                previewContainer.Add(label);
-            }
-        }
         
         public void SetInputField(string input)
         {
@@ -392,6 +387,85 @@ namespace Cardevil.DebugConsole
         {
             Console.ExecuteCommand(input);
         }
+
+        private void UpdatePreviewContainer()
+        {
+            previewContainer.Clear();
+            if (_autoCompleter.SuggestionCount == 0)
+                return;
+
+            // previewContainer가 ScrollView일 수도 있으므로 캐스팅
+
+            var suggestions = _autoCompleter.GetAllSuggestions();
+            Label selectedLabel = null;
+
+            foreach (var suggestion in suggestions)
+            {
+                var label = new Label(suggestion);
+                label.AddToClassList("suggest"); 
+                if (suggestion == _autoCompleter.GetCurrentSuggestion())
+                {
+                    label.AddToClassList("selected");
+                    selectedLabel = label;
+                }
+                // 클릭 시 바로 선택/실행하도록 이벤트 등록
+                label.RegisterCallback<ClickEvent>(_ => _autoCompleter.SetCurrentSuggestion(suggestion));
+                previewContainer.Add(label);
+            }
+            
+            if (previewContainer != null && selectedLabel != null)
+            {
+                previewContainer.schedule.Execute(() =>
+                {
+                    previewContainer.ScrollTo(selectedLabel);
+                });
+            }
+        }
+
+        
+        private void Recall(int targetIndex)
+        {
+            if (targetIndex < 0 || targetIndex >= _submittedCommands.Count)
+                return;
+            _currentRecallIndex = targetIndex;
+            SetInputField(_submittedCommands[_currentRecallIndex]);
+            textField.cursorIndex = textField.value.Length;
+            textField.selectIndex = textField.value.Length;
+        }
+        
+        public void RecallPrevious()
+        {
+            if (_submittedCommands.Count == 0)
+                return;
+            if (_currentRecallIndex == -1)
+            {
+                _currentRecallIndex = _submittedCommands.Count - 1;
+            }
+            else
+            {
+                _currentRecallIndex--;
+                if (_currentRecallIndex < 0)
+                    _currentRecallIndex = 0;
+            }
+            Recall(_currentRecallIndex);
+        }
+        
+        public void RecallNext()
+        {
+            if (_submittedCommands.Count == 0)
+                return;
+            if (_currentRecallIndex == -1)
+            {
+                _currentRecallIndex = 0;
+            }
+            else
+            {
+                _currentRecallIndex++;
+                if (_currentRecallIndex >= _submittedCommands.Count)
+                    _currentRecallIndex = _submittedCommands.Count - 1;
+            }
+            Recall(_currentRecallIndex);
+        }
         
         /// <summary>
         /// 입력이 제출되었을 때 호출됩니다.
@@ -399,15 +473,16 @@ namespace Cardevil.DebugConsole
         /// <param name="input"></param>
         private void OnSubmit(string input)
         {
-            _cachedAutoCompleteInput = "";
+            if (string.IsNullOrWhiteSpace(input))
+                return;
             textField.value = "";
-            _isAutoCompleteRequested = false;
-            _autoCompleteIndex = 0;
-            _suggestions.Clear();
+            _autoCompleter.Clear();
+            _wasAutoCompleteJustRequested = false;
             previewContainer.Clear();
             
             Message(MessageType.Gray,$"> {input}");
             ExecuteCommand(input);
+            _submittedCommands.Add(input);
             // 기다렸다가 스크롤을 맨 아래로 이동
             historyContainer.schedule.Execute(() =>
             {
@@ -428,6 +503,7 @@ namespace Cardevil.DebugConsole
         /// <param name="input">새로 바뀐 텍스트</param>
         private void OnTextChanged(string input)
         {
+            // LogEx.Log($"TextChanged: {input}");
             if(!_useAutoComplete)
                 return;
             if (_wasAutoCompleteJustRequested)
@@ -436,16 +512,13 @@ namespace Cardevil.DebugConsole
                 // 자동완성 요청에 의한 텍스트 변경이므로 무시
                 return;
             }
-            _cachedAutoCompleteInput = input;
-            if(string.IsNullOrWhiteSpace(input))
-            {
-                _isAutoCompleteRequested = false;
-                _autoCompleteIndex = 0;
-                _suggestions.Clear();
-                previewContainer.Clear();
-                return;
-            }
-            RefreshAutoCompleteSuggestions();
+            _autoCompleter.TextInputChanged(input);
+            // if(string.IsNullOrWhiteSpace(input))
+            // {
+            //     previewContainer.Clear();
+            //     return;
+            // }
+            UpdatePreviewContainer();
         }
         
         /// <inheritdoc cref="OnTextFieldUnfocused()"/>
@@ -461,8 +534,8 @@ namespace Cardevil.DebugConsole
         private void OnTextFieldUnfocused()
         {
             previewContainer.Clear();
-            _isAutoCompleteRequested = false;
-            _autoCompleteIndex = 0;
+            _autoCompleter.Clear();
+            previewContainer.Clear();
         }
         
         private void OnTextFieldKeyDown(KeyDownEvent evt)
@@ -482,6 +555,22 @@ namespace Cardevil.DebugConsole
             {
                 // LogEx.Log($"Submitted: {CurrentInput}, {textField.value}");
                 OnSubmit(CurrentInput);
+            }
+            else if (evt.keyCode == KeyCode.UpArrow)
+            {
+                evt.StopPropagation();
+                evt.StopImmediatePropagation();
+                FocusController focusController = textField.panel.focusController;
+                focusController.IgnoreEvent(evt);
+                RecallPrevious();
+            }
+            else if (evt.keyCode == KeyCode.DownArrow)
+            {
+                evt.StopPropagation();
+                evt.StopImmediatePropagation();
+                FocusController focusController = textField.panel.focusController;
+                focusController.IgnoreEvent(evt);
+                RecallNext();
             }
         }
         

--- a/Assets/Scripts/DebugConsole/ConsoleUI.cs
+++ b/Assets/Scripts/DebugConsole/ConsoleUI.cs
@@ -488,7 +488,8 @@ namespace Cardevil.DebugConsole
             {
                 ScrollToBottom();
                 textField.Focus();
-            }).ExecuteLater(1);
+            }).ExecuteLater(5);
+            _currentRecallIndex = -1;
         }
         
         /// <inheritdoc cref="OnTextChanged(string)"/>
@@ -570,6 +571,7 @@ namespace Cardevil.DebugConsole
                 evt.StopImmediatePropagation();
                 FocusController focusController = textField.panel.focusController;
                 focusController.IgnoreEvent(evt);
+                
                 RecallNext();
             }
         }

--- a/Assets/UI Toolkit/DebugConsole/console.uss
+++ b/Assets/UI Toolkit/DebugConsole/console.uss
@@ -104,8 +104,8 @@
 }
 
 .preview {
-    min-height: 20px;
-    max-height: 80px;
+    min-height: 34px;
+    max-height: 82px;
     overflow: hidden;
     flex-direction: row;
     flex-wrap: wrap;
@@ -113,12 +113,21 @@
     padding: 4px;
 }
 
+#PreviewContainer .unity-scroll-view__content-container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: flex-start;
+    min-height: 24px;
+    max-height: 48px;
+}
+
 .preview .suggest {
-    padding-left: 6px;
-    padding-right: 6px;
-    padding-top: 2px;
-    padding-bottom: 2px;
+    padding: 2px 6px;
     border-radius: 4px;
+    font-size: 12px;
+    min-height: 20px;
     background-color: rgb(35, 42, 47);
     color: rgb(137, 255, 163);
     border-width: 1px;

--- a/Assets/UI Toolkit/DebugConsole/console.uxml
+++ b/Assets/UI Toolkit/DebugConsole/console.uxml
@@ -6,7 +6,7 @@
             <ui:Label name="Hint" text="` to toggle • TAB to autocomplete • ENTER to run" focusable="false" parse-escape-sequences="false" class="hint" />
         </ui:VisualElement>
         <ui:ScrollView name="HistoryContainer" vertical-scroller-visibility="Auto" class="history" />
-        <ui:VisualElement name="PreviewContainer" class="preview info" />
+        <ui:ScrollView name="PreviewContainer" vertical-scroller-visibility="Auto" horizontal-scroller-visibility="Auto" mode="Horizontal" class="preview info" />
         <ui:TextField name="InputField" isDelayed="true" focusable="true" is-delayed="false" auto-correction="false" class="input" style="flex-direction: row-reverse;" />
         <ui:VisualElement name="resize-east" class="resize-handle-east" />
         <ui:VisualElement name="resize-south" class="resize-handle-south" />


### PR DESCRIPTION

---

# 🚀 자동완성 기능 추가 및 PreviewContainer 구조 개선

## 개요

UI 콘솔에 **자동완성(AutoComplete)** 을 도입했습니다.

* `Tab` : 가능한 제안을 순환하며 자동완성
* `↑ / ↓` : 과거 입력 히스토리 탐색
  또한 `PreviewContainer` 를 **`ScrollView`** 기반으로 교체해, 제안/히스토리 표시와 스크롤 인터랙션 안정성을 높였습니다.

> 참고 스크린샷
> ![image](https://github.com/user-attachments/assets/15d1e64a-4a5e-4f5a-8798-40416b52a55b)

---

## 변경 사항

### 1) 콘솔 자동완성

* `Cardevil.DebugConsole.AutoCompleter` 신규 도입

  * 입력 변화에 따른 제안 캐싱: `TextInputChanged(string input)`
  * 제안 순회: `GetNextSuggestion() / GetPreviousSuggestion()`
  * 현재 제안 조회/선택: `GetCurrentSuggestion(), SetCurrentIndex(), SetCurrentSuggestion()`
  * 전체 제안 노출: `GetAllSuggestions()`
  * 제안 생성: `GetSuggestions(string input)`

    * 명령어 파트(첫 토큰) → `CommandLibrary.GetAllCommands()`에서 prefix 매칭
    * 인자 파트 → 해당 커맨드의 `AutoComplete(args, ref suggestions)` 위임

* 히스토리 탐색(↑/↓)과 자동완성(Tab) 입력 흐름을 분리하여, 사용자가 **히스토리 탐색 중에도 현재 입력 기반 자동완성**을 자연스럽게 사용 가능

### 2) 프리뷰 컨테이너 교체

* `PreviewContainer` → **`ScrollView`** 로 전환

  * 많은 제안/히스토리가 쌓여도 안정적으로 스크롤 가능
  * 키보드/마우스 혼합 입력 시 포커스 혼선 감소

---

## 사용 방법

* 콘솔에서:

  * 명령 타이핑 중 **`Tab`** 을 눌러 제안을 순환
  * **`↑ / ↓`** 로 과거 명령 히스토리 탐색
* `AutoCompleter` 통합 포인트(요약):

  * 텍스트 변경 시 `autoCompleter.TextInputChanged(input)`
  * `Tab` 입력 시 `autoCompleter.GetNextSuggestion()` 결과를 입력란에 반영
  * 화살표로 제안 목록을 하이라이트할 경우 `SetCurrentIndex()` 사용
  * 커맨드 구현 측은 기존처럼 `IConsoleCommand.AutoComplete(args, ref suggestions)` 오버라이드로 제안 제공
---
## 특징

* 각 커맨드가 스스로 인자 자동완성을 제공(`IConsoleCommand.AutoComplete`) → 기능 추가 시 콘솔 코어 수정 최소화
---

## 알려진 문제 (Known Issues)

* `AutoCompleter.GetSuggestions` 의 **임시 배열/리스트 할당**이 잦음
  → 대용량 입력/초고빈도 타이핑에서 GC 스파이크 가능성


