### PR TITLE
FIX: 빠른 드래그 시 카드 시각적 순서 오류 수정 / 인덱스 관리 구조 개선

### DIFF
--- a/Assets/Scripts/Cards/Evaluations/CardResultContext.cs
+++ b/Assets/Scripts/Cards/Evaluations/CardResultContext.cs
@@ -91,18 +91,18 @@ namespace Cardevil.Cards.Evaluations
         public CardResult(List<HandRanking> rankings, List<Card> numberDatas, List<Card> moveDatas)
         {
             Rankings = rankings;
-            Numbers = numberDatas.Select(n => n.data.Number)
+            Numbers = numberDatas.Select(n => n.Data.Number)
                     .ToList();
-            Moves = moveDatas.Select(m => m.data.Move)
+            Moves = moveDatas.Select(m => m.Data.Move)
                     .ToList(); ;
         }
 
         public CardResult(List<Card> numberDatas, List<Card> moveDatas)
         {
             Rankings = new() { HandRanking.None };
-            Numbers = numberDatas.Select(n => n.data.Number)
+            Numbers = numberDatas.Select(n => n.Data.Number)
                     .ToList();
-            Moves = moveDatas.Select(m => m.data.Move)
+            Moves = moveDatas.Select(m => m.Data.Move)
                     .ToList(); ;
         } 
 

--- a/Assets/Scripts/Cards/Evaluations/CardResultEvaluator.cs
+++ b/Assets/Scripts/Cards/Evaluations/CardResultEvaluator.cs
@@ -15,9 +15,9 @@ namespace Cardevil.Cards.Evaluations
         {
             CardResult result;
 
-            cards.Sort((a, b) => a.HandIndex.CompareTo(b.HandIndex));
-            var numbers = cards.Where(c => c.data.valueType == CardData.ValueType.Number).ToList();
-            var moves = cards.Where(c => c.data.valueType == CardData.ValueType.Move).ToList();
+            // cards.Sort((a, b) => {});
+            var numbers = cards.Where(c => c.Data.valueType == CardData.ValueType.Number).ToList();
+            var moves = cards.Where(c => c.Data.valueType == CardData.ValueType.Move).ToList();
 
             // move only
             if (numbers.Count == 0)
@@ -61,10 +61,10 @@ namespace Cardevil.Cards.Evaluations
             {
                 case HandRanking.High:
                     var top = numbers.Aggregate((best, cur) =>
-                        cur.data.Number.NumberValue > best.data.Number.NumberValue ? cur : best);
+                        cur.Data.Number.NumberValue > best.Data.Number.NumberValue ? cur : best);
                     using (var high = EvaluationAction.Get())
                     {
-                        high.SetValue(priority: p++, EffectEvaluation.Plus, top.data.Number.NumberValue);
+                        high.SetValue(priority: p++, EffectEvaluation.Plus, top.Data.Number.NumberValue);
                         high.SetVisual(top);
                     }
                     break;
@@ -82,7 +82,7 @@ namespace Cardevil.Cards.Evaluations
                     {
                         using (var c = EvaluationAction.Get())
                         {
-                            c.SetValue(priority: p++, EffectEvaluation.Plus, card.data.Number.NumberValue);
+                            c.SetValue(priority: p++, EffectEvaluation.Plus, card.Data.Number.NumberValue);
                             c.SetVisual(card);
                         }
                     }
@@ -93,11 +93,11 @@ namespace Cardevil.Cards.Evaluations
             void AddEventByCount(List<Card> cards, int count)
             {
                 foreach (var card in cards
-                    .GroupBy(n => n.data.Number.NumberValue)
+                    .GroupBy(n => n.Data.Number.NumberValue)
                     .Where(g => g.Count() == count)
                     .SelectMany(g => g))
                 {
-                    var val = card.data.Number.NumberValue;
+                    var val = card.Data.Number.NumberValue;
                     using (var act = EvaluationAction.Get())
                     {
                         act.SetValue(priority: p++, EffectEvaluation.Plus, val);
@@ -160,7 +160,7 @@ namespace Cardevil.Cards.Evaluations
         /// </summary>
         public static HandRanking GetRanking(List<Card> cards)
         {
-            var numbers = cards.Where(c => c.data.valueType == CardData.ValueType.Number)
+            var numbers = cards.Where(c => c.Data.valueType == CardData.ValueType.Number)
                     .ToList();
 
             if (numbers.Count == 0)
@@ -177,8 +177,8 @@ namespace Cardevil.Cards.Evaluations
         {
             var rankings = new List<HandRanking>();
 
-            var numberDatas = numberCards.Where(c => c.data.valueType == CardData.ValueType.Number)
-                .Select(c => c.data)
+            var numberDatas = numberCards.Where(c => c.Data.valueType == CardData.ValueType.Number)
+                .Select(c => c.Data)
                 .ToList();
 
             if (IsStraightFlush(numberDatas))

--- a/Assets/Scripts/Cards/Interactions/Card.cs
+++ b/Assets/Scripts/Cards/Interactions/Card.cs
@@ -1,3 +1,4 @@
+using Cardevil.Attributes;
 using Cardevil.Cards.Evaluations;
 using Cardevil.Core;
 using Cardevil.Pools;
@@ -10,84 +11,60 @@ namespace Cardevil.Cards.Interactions
 {
     [RequireComponent(typeof(Poolable))]
     public class Card : MonoBehaviour, IEvaluateVisual, IClearable,
-        IDragHandler, IBeginDragHandler, IEndDragHandler, IPointerEnterHandler, IPointerExitHandler, IPointerUpHandler, IPointerDownHandler
+                        IDragHandler, IBeginDragHandler, IEndDragHandler, IPointerEnterHandler, IPointerExitHandler, IPointerUpHandler, IPointerDownHandler
     {
-        private Poolable _poolable;
-
-        [Header("Card")]
-        public CardData data;
-        private bool isDiscarded = false;
-        private StageCardsContext ctx;
-
-        [Header("Visual")]
-        [SerializeField] GameObject cardVisualPrefab;
+        [Header("SO")]
         [SerializeField] CardVisualSettingSO visualSetting;
-        [SerializeField] CardVisual _cardVisual;
-        private bool _isReroll;
+        
+        [Header("Card")]
+        [SerializeField, VisibleOnly] CardData _data;
+        [SerializeField, VisibleOnly] CardVisual _visual;
+        [SerializeField, VisibleOnly] DragState _drag;
 
-        private Vector3 pointerOffset;
-        private float pointerDownTime;
-        private float pointerUpTime;
+        public event Action<Card> PointerDown, PointerUp;
+        public event Action<Card> DragStarted, DragEnded;
+        public Action<Card> ValueSelectionStarted, ValueSelectionEnded;
 
-
-        [Header("Drag")]
-        public bool isSelected;
-        public bool isDragging;
-
-
-        [Header("Events")]
-        public Action<Card> OnPointerDownEvent;
-        public Action<Card> OnPointerUpEvent;
-        public Action<Card> OnBeginDragEvent;
-        public Action<Card> OnEndDragEvent;
-        public Action<Card> OnSelectValueStartEvent;
-        public Action<Card> OnSelectValueEndEvent;
-
-        public Action OnRerollDraw;
-        public Action<Transform> OnRerollDiscard;
-        public Action OnRerollEnd;
-        public Action OnDraw;
-        public Action OnDiscard;
-        public Action OnDestory;
+        public Action RerollDrawn;
+        public Action<Transform> RerollDiscarded;
+        public Action RerollEnded;
+        public Action Drawn, Discarded, Destroyed;
 
 
-        private CardHandBar handBar;
+
+        private Poolable _poolable;
+        private CardHandBar _handBar;
+
+
+
+        public CardData Data => _data;
 
         public CardVisual CardVisual
         {
             get
             {
-                if (_cardVisual == null) _cardVisual = CreateCardVisual();
-                return _cardVisual;
+                if (_visual == null) _visual = CreateCardVisual();
+                return _visual;
             }
         }
 
-        public bool IsReroll { get => _isReroll; set => _isReroll = value; }
-
-        public int HandIndex => ctx.Hand.IndexOf(this);
-
-        public float NormalizedPosition => Util.Remap(HandIndex, 0, transform.parent.parent.childCount - 1, 0, 1);
+        public bool IsSelected  => _drag.isSelected;
+        public bool IsDragging  => _drag.isDragging;
+        public bool IsReroll    => _drag.isReroll;
 
         private bool CanDrag
         {
             get
             {
-                if (isDiscarded)
-                    return false;
-
-                if (_isReroll)
-                    return false;
-
-                if (handBar.DraggedCard != null
-                    && handBar.DraggedCard != this)
-                    return false;
-
-                if (!handBar.CanInput)
-                    return false;
+                if (_drag.isDiscarded) return false;
+                if (_drag.isReroll) return false;
+                if (!_handBar.CanInput) return false;
+                if (_handBar.DraggedCard != null && _handBar.DraggedCard != this) return false;
 
                 return true;
             }
         }
+
 
 
         void Awake()
@@ -99,50 +76,44 @@ namespace Cardevil.Cards.Interactions
 
         public void Clear()
         {
-            _isReroll = false;
-            isDragging = false;
-            isSelected = false;
-            isDiscarded = false;
-            _cardVisual = null;
+            _drag.isReroll = false;
+            _drag.isDragging = false;
+            _drag.isSelected = false;
+            _drag.isDiscarded = false;
+            _visual = null;
         }
 
-        public void Init(CardData data, StageCardsContext ctx)
+
+        public void SpawnInHand(CardHandBar handBar, CardData data)
         {
-            this.ctx = ctx;
-            this.data = data;
-            _isReroll = true;
+            _data = data;
+            _handBar = handBar;
+            _drag.isReroll = false;
             CardVisual.Init(this);
         }
 
-        public void Init(StageCardsContext ctx, CardHandBar handBar, CardData data)
+        public void SpawnAsReroll(CardData data)
         {
-            this.ctx = ctx;
-            this.data = data;
-            this.handBar = handBar;
-            _isReroll = false;
+            _data = data;
+            _drag.isReroll = true;
             CardVisual.Init(this);
         }
 
-        public void SetHandBar(CardHandBar handBar)
+        public void CompleteReroll(CardHandBar handBar)
         {
-            this.handBar = handBar;
-            _isReroll = false;
-            OnRerollEnd?.Invoke();
+            _handBar = handBar;
+            _drag.isReroll = false;
+            RerollEnded?.Invoke();
         }
-
-
-
 
         void Update()
         {
-            if (isDiscarded)
-                return;
+            if (_drag.isDiscarded) return;
 
-            // ClampPosition();
-
-            if (isDragging)
+            if (_drag.isDragging)
             {
-                var targetPosition = Input.mousePosition - pointerOffset;
+                // var targetPosition = Input.mousePosition - pointerOffset;
+                var targetPosition = Input.mousePosition;
                 var direction = (targetPosition - transform.position).normalized;
 
                 var neededVelocity = Vector2.Distance(transform.position, targetPosition) / Time.deltaTime;
@@ -152,20 +123,49 @@ namespace Cardevil.Cards.Interactions
             }
         }
 
-
-
-        private void ClampPosition()
+        public void SetSlot(Transform slot, bool isDragging = false)
         {
-            // Vector2 screenBounds = Camera.main.ScreenToWorldPoint(new Vector3(Screen.width, Screen.height, Camera.main.transform.position.z));
-            // Vector3 clampedPosition = transform.position;
-            // clampedPosition.x = Mathf.Clamp(clampedPosition.x, -screenBounds.x, screenBounds.x);
-            // clampedPosition.y = Mathf.Clamp(clampedPosition.y, -screenBounds.y, screenBounds.y);
-            // transform.position = new Vector3(clampedPosition.x, clampedPosition.y, 0);
+            transform.SetParent(slot);
+
+            if (!isDragging)
+                transform.localPosition = _drag.isSelected
+                    ? new Vector3(0, visualSetting.SelectOffset, 0)
+                    : Vector3.zero;
+
+            _visual.UpdateIndex();
         }
+
+        public void Discard()
+        {
+            _drag.isDiscarded = true;
+            Discarded?.Invoke();
+        }
+
+        public void Destroy()
+        {
+            Destroyed?.Invoke();
+            Managers.Resource.Destroy(gameObject);
+        }
+
+        public void ExecuteEvaluationAction()
+        {
+            _visual.ExecuteEvaluationAction();
+        }
+
+        private CardVisual CreateCardVisual()
+        {
+            var visualHandler = FindAnyObjectByType<CardVisualHandler>();
+            if (visualHandler == null)
+                LogEx.LogError("Visual Handler를 찾을 수 없음.");
+
+            var v = Managers.Resource.Instantiate("Cards/CardVisual", visualHandler.transform).GetComponent<CardVisual>();
+            return v;
+        }
+        
 
 
         #region Point Event
-        
+
         public void OnPointerEnter(PointerEventData eventData)
         {
             if (!CanDrag)
@@ -185,8 +185,8 @@ namespace Cardevil.Cards.Interactions
                 if (!CanDrag)
                     return;
 
-                OnPointerDownEvent?.Invoke(this);
-                pointerDownTime = Time.time;
+                PointerDown?.Invoke(this);
+                _drag.pointerDownTime = Time.time;
 
                 var mousePosition = Input.mousePosition;
                 var offset = mousePosition - transform.position;
@@ -194,14 +194,14 @@ namespace Cardevil.Cards.Interactions
 
             else if (eventData.button == PointerEventData.InputButton.Right)
             {
-                OnPointerDownEvent?.Invoke(this);
+                PointerDown?.Invoke(this);
 
-                if (!data.CanOpenSelection)
+                if (!_data.CanOpenSelection)
                     return;
 
                 // TODO: 실행자 수정
-                handBar.selectContainer.OpenSelection(this);
-                OnSelectValueStartEvent?.Invoke(this);
+                _handBar.selectContainer.OpenSelection(this);
+                ValueSelectionStarted?.Invoke(this);
             }
         }
 
@@ -213,8 +213,8 @@ namespace Cardevil.Cards.Interactions
             if (!CanDrag)
                 return;
 
-            OnBeginDragEvent?.Invoke(this);
-            isDragging = true;
+            DragStarted?.Invoke(this);
+            _drag.isDragging = true;
         }
 
         public void OnDrag(PointerEventData eventData)
@@ -229,8 +229,8 @@ namespace Cardevil.Cards.Interactions
             if (!CanDrag)
                 return;
 
-            OnEndDragEvent?.Invoke(this);
-            isDragging = false;
+            DragEnded?.Invoke(this);
+            _drag.isDragging = false;
         }
 
         public void OnPointerUp(PointerEventData eventData)
@@ -240,27 +240,27 @@ namespace Cardevil.Cards.Interactions
                 if (!CanDrag)
                     return;
 
-                OnPointerUpEvent?.Invoke(this);
-                pointerUpTime = Time.time;
-                if (pointerUpTime - pointerDownTime > visualSetting.ClickDetectThreshold)
+                PointerUp?.Invoke(this);
+                _drag.pointerUpTime = Time.time;
+                if (_drag.pointerUpTime - _drag.pointerDownTime > visualSetting.ClickDetectThreshold)
                     return;
 
-                isSelected = Managers.Card.StageCardsCtx.SelectCount < 4 && !isSelected;
+                _drag.isSelected = Managers.Card.StageCardsCtx.SelectCount < 4 && !_drag.isSelected;
 
-                if (isSelected)
+                if (_drag.isSelected)
                 {
                     transform.localPosition = new Vector3(0, visualSetting.SelectOffset, transform.localPosition.z);
-                    handBar.Select(this);
+                    _handBar.Select(this);
                 }
                 else
                 {
                     transform.localPosition = new Vector3(0, 0, transform.localPosition.z);
-                    handBar.Deselect(this);
+                    _handBar.Deselect(this);
                 }
             }
             else if (eventData.button == PointerEventData.InputButton.Right)
             {
-                OnPointerUpEvent?.Invoke(this);
+                PointerUp?.Invoke(this);
             }
         }
 
@@ -268,43 +268,11 @@ namespace Cardevil.Cards.Interactions
 
 
 
-        public void SetSlot(Transform slot, bool isDragging = false)
+        [Serializable]
+        private struct DragState
         {
-            transform.SetParent(slot);
-
-            if (!isDragging)
-                transform.localPosition = isSelected
-                    ? new Vector3(0, visualSetting.SelectOffset, 0)
-                    : Vector3.zero;
-
-            _cardVisual.UpdateIndex();
-        }
-
-        public void Discard()
-        {
-            isDiscarded = true;
-            OnDiscard?.Invoke();
-        }
-
-        public void Destroy()
-        {
-            OnDestory?.Invoke();
-            Managers.Resource.Destroy(gameObject);
-        }
-
-        public void ExecuteEvaluationAction()
-        {
-            _cardVisual.ExecuteEvaluationAction();
-        }
-
-        private CardVisual CreateCardVisual()
-        {
-            var visualHandler = FindAnyObjectByType<CardVisualHandler>();
-            if (visualHandler == null)
-                LogEx.LogError("Visual Handler를 찾을 수 없음.");
-
-            var v = Managers.Resource.Instantiate("Cards/CardVisual", visualHandler.transform).GetComponent<CardVisual>();
-            return v;
+            public bool isSelected, isDragging, isDiscarded, isReroll;
+            public float pointerDownTime, pointerUpTime;
         }
     }
 }

--- a/Assets/Scripts/Cards/Interactions/CardHandBar.cs
+++ b/Assets/Scripts/Cards/Interactions/CardHandBar.cs
@@ -161,7 +161,7 @@ namespace Cardevil.Cards.Interactions
                 return;
 
             DraggedCard.transform.DOLocalMove(
-                endValue: DraggedCard.isSelected
+                endValue: DraggedCard.IsSelected
                     ? new Vector3(0, visualSetting.SelectOffset, 0)
                     : Vector3.zero,
                 duration: visualSetting.EndDragTweenDuration)
@@ -176,21 +176,34 @@ namespace Cardevil.Cards.Interactions
         // - - - - - - - - - - -
         private void DetectSwap()
         {
+            var dragged = DraggedCard;
+            if (dragged == null || ctx == null) return;
+
+            if (!dragged.IsDragging) return;
+
+            var draggedX = dragged.transform.position.x;
+            if (!ctx.TryGetIndex(dragged, out var draggedIdx)) return;
+
             for (int i = 0; i < ctx.HandCount; i++)
             {
-                if (DraggedCard.transform.position.x > ctx.GetHandCard(i).transform.position.x)
-                    if (DraggedCard.HandIndex < ctx.GetHandCard(i).HandIndex)
-                    {
-                        Swap(i);
-                        break;
-                    }
+                var other = ctx.GetHandCard(i);
+                if (other == null || other == dragged) continue;
 
-                if (DraggedCard.transform.position.x < ctx.GetHandCard(i).transform.position.x)
-                    if (DraggedCard.HandIndex > ctx.GetHandCard(i).HandIndex)
-                    {
-                        Swap(i);
-                        break;
-                    }
+                var otherX = other.transform.position.x;
+
+                if (!ctx.TryGetIndex(other, out var otherIdx)) continue;
+
+                if (draggedX > otherX && draggedIdx < otherIdx)
+                {
+                    Swap(i);
+                    break;
+                }
+
+                if (draggedX < otherX && draggedIdx > otherIdx)
+                {
+                    Swap(i);
+                    break;
+                }
             }
         }
 
@@ -198,7 +211,7 @@ namespace Cardevil.Cards.Interactions
         {
             IsSwapping = true;
 
-            _manager.StageCardsCtx.Swap(DraggedCard.HandIndex, index);
+            _manager.StageCardsCtx.Swap(DraggedCard, index);
             UpdateSlots();
 
             IsSwapping = false;
@@ -208,8 +221,8 @@ namespace Cardevil.Cards.Interactions
         {
             foreach (var card in ctx.Hand)
             {
-                card.SetSlot(slots[card.HandIndex], isDragging: card == DraggedCard);
-                card.IsReroll = false;
+                if (!ctx.TryGetIndex(card, out var idx)) continue;
+                card.SetSlot(slots[idx], isDragging: card == DraggedCard);
             }          
         }
 
@@ -217,15 +230,15 @@ namespace Cardevil.Cards.Interactions
         {
             var card = ctx.GetHandCard(index);
             card.SetSlot(slots[index], isDragging: card == DraggedCard);
-            card.SetHandBar(this);
+            card.CompleteReroll(this);
             AddListeners(card);
         }
 
         private void AddListeners(Card card)
         {
-            card.OnBeginDragEvent += BeginDrag;
-            card.OnEndDragEvent += EndDrag;
-            card.OnSelectValueEndEvent += OnSelectValueEnd;
+            card.DragStarted += BeginDrag;
+            card.DragEnded += EndDrag;
+            card.ValueSelectionEnded += OnSelectValueEnd;
         }
 
 
@@ -272,7 +285,7 @@ namespace Cardevil.Cards.Interactions
             var count = Managers.Card.MaxHandCount - ctx.HandCount;
             for (int i = 0; i < count; i++)
             {
-                Spawn().OnDraw?.Invoke();
+                Spawn().Drawn?.Invoke();
                 await UniTask.Delay(TimeSpan.FromSeconds(visualSetting.DrawInterval));
             }
 
@@ -298,7 +311,7 @@ namespace Cardevil.Cards.Interactions
                 return null;
 
             var card = Managers.Resource.Instantiate("Cards/Card").GetComponent<Card>();
-            card.Init(ctx, handBar: this, cardData);
+            card.SpawnInHand(handBar: this, cardData);
 
             // 이벤트 구독
             AddListeners(card);

--- a/Assets/Scripts/Cards/Interactions/CardVisual.cs
+++ b/Assets/Scripts/Cards/Interactions/CardVisual.cs
@@ -103,7 +103,7 @@ namespace Cardevil.Cards.Interactions
             if (isDrawing)
                 return;
 
-            var verticalOffset = Vector3.up * (parentCard.isDragging ? 0 : curveYOffset);
+            var verticalOffset = Vector3.up * (parentCard.IsDragging ? 0 : curveYOffset);
             transform.position = Vector3.Lerp(transform.position, parentCard.transform.position + verticalOffset, t: visualSetting.FollowSpeed * Time.deltaTime);
         }
 
@@ -111,7 +111,7 @@ namespace Cardevil.Cards.Interactions
         {
             Vector3 movement = transform.position - parentCard.transform.position;
             movementDelta = Vector3.Lerp(movementDelta, movement, 20 * Time.deltaTime);
-            Vector3 movementRotation = (parentCard.isDragging ? movementDelta : movement) * visualSetting.RotationAmount;
+            Vector3 movementRotation = (parentCard.IsDragging ? movementDelta : movement) * visualSetting.RotationAmount;
             rotationDelta = Vector3.Lerp(rotationDelta, movementRotation, visualSetting.RotationSpeed * Time.deltaTime);
 
             transform.localEulerAngles = new Vector3(transform.localEulerAngles.x, transform.localEulerAngles.y, Mathf.Clamp(rotationDelta.x, -50f, 50f));
@@ -119,11 +119,14 @@ namespace Cardevil.Cards.Interactions
 
         private void CurvePosition()
         {
-            if (parentCard.IsReroll)
-                return;
+            if (parentCard.IsReroll) return;
+            if (!Managers.Card.StageCardsCtx.TryGetIndex(parentCard, out var idx)) return;
+
             var c = visualSetting.Curve;
-            curveYOffset = c.positioning.Evaluate(parentCard.NormalizedPosition) * c.positioningInfluence * (Managers.Card.StageCardsCtx.HandCount - 1);
-            curveRotationOffset = c.rotation.Evaluate(parentCard.NormalizedPosition);
+
+            var factor = (float)idx / (Managers.Card.MaxHandCount - 1);
+            curveYOffset = c.positioning.Evaluate(factor) * c.positioningInfluence * (Managers.Card.MaxHandCount - 1);
+            curveRotationOffset = c.rotation.Evaluate(factor);
         }
 
         private void TiltCard()
@@ -132,7 +135,7 @@ namespace Cardevil.Cards.Interactions
                 return;
 
             var c = visualSetting.Curve;
-            float tiltZ = parentCard.isDragging ? 0 : (curveRotationOffset * (c.rotationInfluence * (Managers.Card.StageCardsCtx.HandCount - 1)));
+            float tiltZ = parentCard.IsDragging ? 0 : (curveRotationOffset * (c.rotationInfluence * (Managers.Card.StageCardsCtx.HandCount - 1)));
             float lerpZ = Mathf.LerpAngle(tiltZ, shakeObject.localEulerAngles.z, visualSetting.TiltSpeed / 2 * Time.deltaTime);
             shakeObject.localEulerAngles = new Vector3(0, 0, lerpZ);
         }
@@ -142,7 +145,8 @@ namespace Cardevil.Cards.Interactions
 
         public void UpdateIndex()
         {
-            transform.SetSiblingIndex(parentCard.HandIndex);
+            if (!Managers.Card.StageCardsCtx.TryGetIndex(parentCard, out var idx)) return;
+            transform.SetSiblingIndex(idx);
         }
 
 
@@ -152,38 +156,38 @@ namespace Cardevil.Cards.Interactions
         {
             if (p == null) return;
 
-            p.OnPointerDownEvent += OnPointerDown;
-            p.OnPointerUpEvent += OnPointerUp;
-            p.OnBeginDragEvent += OnBeginDrag;
-            p.OnEndDragEvent += OnEndDrag;
-            p.OnSelectValueStartEvent += OnSelectStarted;
-            p.OnSelectValueEndEvent += OnSelectEnded;
+            p.PointerDown += OnPointerDown;
+            p.PointerUp += OnPointerUp;
+            p.DragStarted += OnBeginDrag;
+            p.DragEnded += OnEndDrag;
+            p.ValueSelectionStarted += OnSelectStarted;
+            p.ValueSelectionEnded += OnSelectEnded;
 
-            p.OnRerollDraw += OnRerollDraw;
-            p.OnRerollDiscard += OnRerollDiscard;
-            p.OnRerollEnd += OnRerollEnd;
-            p.OnDraw += OnDraw;
-            p.OnDiscard += OnDiscard;
-            p.OnDestory += Destroy;
+            p.RerollDrawn += OnRerollDraw;
+            p.RerollDiscarded += OnRerollDiscard;
+            p.RerollEnded += OnRerollEnd;
+            p.Drawn += OnDraw;
+            p.Discarded += OnDiscard;
+            p.Destroyed += Destroy;
         }
 
         private void UnsubscribeFromParent(Card p)
         {
             if (p == null) return;
 
-            p.OnPointerDownEvent -= OnPointerDown;
-            p.OnPointerUpEvent -= OnPointerUp;
-            p.OnBeginDragEvent -= OnBeginDrag;
-            p.OnEndDragEvent -= OnEndDrag;
-            p.OnSelectValueStartEvent -= OnSelectStarted;
-            p.OnSelectValueEndEvent -= OnSelectEnded;
+            p.PointerDown -= OnPointerDown;
+            p.PointerUp -= OnPointerUp;
+            p.DragStarted -= OnBeginDrag;
+            p.DragEnded -= OnEndDrag;
+            p.ValueSelectionStarted -= OnSelectStarted;
+            p.ValueSelectionEnded -= OnSelectEnded;
 
-            p.OnRerollDraw -= OnRerollDraw;
-            p.OnRerollDiscard -= OnRerollDiscard;
-            p.OnRerollEnd -= OnRerollEnd;
-            p.OnDraw -= OnDraw;
-            p.OnDiscard -= OnDiscard;
-            p.OnDestory -= Destroy;
+            p.RerollDrawn -= OnRerollDraw;
+            p.RerollDiscarded -= OnRerollDiscard;
+            p.RerollEnded -= OnRerollEnd;
+            p.Drawn -= OnDraw;
+            p.Discarded -= OnDiscard;
+            p.Destroyed -= Destroy;
         }
 
         #endregion
@@ -308,7 +312,7 @@ namespace Cardevil.Cards.Interactions
 
         private void UpdateVisual()
         {
-            spriteFactory.UpdataVisual(parentCard.data, frontImage, numberImages[0]);
+            spriteFactory.UpdataVisual(parentCard.Data, frontImage, numberImages[0]);
         }
 
         public void ExecuteEvaluationAction()

--- a/Assets/Scripts/Cards/Interactions/Rerolls/RerollHandler.cs
+++ b/Assets/Scripts/Cards/Interactions/Rerolls/RerollHandler.cs
@@ -107,7 +107,7 @@ namespace Cardevil
                 // 버리기 Tween
                 foreach (var card in ctx.Hand)
                 {
-                    card.OnRerollDiscard?.Invoke(deck.Front);
+                    card.RerollDiscarded?.Invoke(deck.Front);
                     await UniTask.Delay(TimeSpan.FromSeconds(discard));
                 }
 
@@ -119,12 +119,12 @@ namespace Cardevil
                 {
                     var cardData = ctx.PopCard();
                     if (cardData == null) return null;
-                    // var card = Instantiate(cardPrefab).GetComponent<Card>();
                     var card = Managers.Resource.Instantiate("Cards/Card").GetComponent<Card>();
-                    card.Init(cardData, ctx);
+                    card.SpawnAsReroll(cardData);
 
                     ctx.Draw(card);
-                    card.SetSlot(slots[card.HandIndex]);
+                    if (!ctx.TryGetIndex(card, out var idx)) return null;
+                    card.SetSlot(slots[idx]);
 
                     return card;
                 }
@@ -132,7 +132,7 @@ namespace Cardevil
                 // 카드 소환
                 for (int i = 0; i < slots.Count; i++)
                 {
-                    Spawn().OnRerollDraw?.Invoke();
+                    Spawn().RerollDrawn?.Invoke();
                     await UniTask.Delay(TimeSpan.FromSeconds(draw));
                 }
 
@@ -225,54 +225,3 @@ namespace Cardevil
         }
     }
 }
-
-
-        // Reroll
-        // - - - - - - - - - - -
-
-        // private void InitRerollPanel()
-        // {
-        //     endRerollButton.onClick.AddListener(EndReroll);
-        //     rerollButton.onClick.AddListener(Reroll);
-        //     toggleInGamePreviewButton.onClick.AddListener(ToggleStagePreview);
-
-        //     rerollPanel.gameObject.SetActive(true);
-        //     toggleInGamePreviewButton.gameObject.SetActive(true);
-        //     deckCountText.gameObject.SetActive(false);
-
-        //     Managers.Game.PlayerStatus.RerollTicket = initialRerollTicketCount; // 임시
-        //     _ = RerollAsync();
-        // }
-
-
-        // 카드 선택을 끝냄.
-        // private void EndReroll()
-        // {
-        //     UpdateSlot();
-
-        //     rerollPanel.gameObject.SetActive(false);
-        //     toggleInGamePreviewButton.gameObject.SetActive(false);
-        //     deckCountText.gameObject.SetActive(true);
-
-        //     rerollCmp.TrySetResult();
-        // }
-
-        // private void ToggleStagePreview()
-        // {
-        //     isPreviewInGame = !isPreviewInGame;
-
-        //     if (isPreviewInGame)
-        //     {
-        //         toggleInGamePreviewButton.GetComponentInChildren<Text>().text = "카드 선택하기";
-        //         rerollPanel.color = new Color(1, 1, 1, 0);
-        //     }
-        //     else
-        //     {
-        //         toggleInGamePreviewButton.GetComponentInChildren<Text>().text = "인게임 미리 보기";
-        //         rerollPanel.color = new Color(0, 0, 0, .85f);
-        //     }
-
-        //     rerollButton.gameObject.SetActive(!isPreviewInGame);
-        //     endRerollButton.gameObject.SetActive(!isPreviewInGame);
-        //     cardVisualHandler.SetActive(!isPreviewInGame);
-        // }

--- a/Assets/Scripts/Cards/Interactions/SelectContainer.cs
+++ b/Assets/Scripts/Cards/Interactions/SelectContainer.cs
@@ -58,13 +58,13 @@ namespace Cardevil.Cards.Interactions
             options = new();
             index = 0;
 
-            if (card.data.valueType == CardData.ValueType.Number)
+            if (card.Data.valueType == CardData.ValueType.Number)
             {
-                switch (card.data.selectType)
+                switch (card.Data.selectType)
                 {
                     case CardData.SelectType.Multiple:
-                        AddOption(card.data.DefaultNumber.NumberValue);
-                        foreach (var number in card.data.NumberOptions)
+                        AddOption(card.Data.DefaultNumber.NumberValue);
+                        foreach (var number in card.Data.NumberOptions)
                             AddOption(number);
                         break;
 
@@ -74,13 +74,13 @@ namespace Cardevil.Cards.Interactions
                         break;
                 }
             }
-            else if (card.data.valueType == CardData.ValueType.Move)
+            else if (card.Data.valueType == CardData.ValueType.Move)
             {
-                switch (card.data.selectType)
+                switch (card.Data.selectType)
                 {
                     case CardData.SelectType.Multiple:
-                        AddOption(card.data.DefaultMove.DirectionValue);
-                        AddOption(card.data.DefaultMove.DirectionValue.Opposite());
+                        AddOption(card.Data.DefaultMove.DirectionValue);
+                        AddOption(card.Data.DefaultMove.DirectionValue.Opposite());
                         break;
 
                     case CardData.SelectType.All:
@@ -99,11 +99,11 @@ namespace Cardevil.Cards.Interactions
         private void OnButtonSelected(int index)
         {
             if (options[index].Item1 != 0)
-                card.data.SelectValue(options[index].Item1);
+                card.Data.SelectValue(options[index].Item1);
             else
-                card.data.SelectValue(options[index].Item2);
+                card.Data.SelectValue(options[index].Item2);
 
-            card.OnSelectValueEndEvent?.Invoke(card);
+            card.ValueSelectionEnded?.Invoke(card);
             SetObjectActive(false);
         }
 
@@ -118,7 +118,7 @@ namespace Cardevil.Cards.Interactions
             backgroundButton.gameObject.SetActive(value);
             gameObject.SetActive(value);
             if (!value)
-                card.OnSelectValueEndEvent?.Invoke(card);
+                card.ValueSelectionEnded?.Invoke(card);
         }
     }
 }

--- a/Assets/Scripts/Cards/Interactions/StageCardContext.cs
+++ b/Assets/Scripts/Cards/Interactions/StageCardContext.cs
@@ -6,8 +6,6 @@ using System;
 using Random = UnityEngine.Random;
 using Cardevil.Cards.Evaluations;
 using Cardevil.Core;
-using Cardevil.Utils;
-using Database.Generated;
 
 namespace Cardevil.Cards
 {
@@ -33,7 +31,7 @@ namespace Cardevil.Cards
         public void Shuffle()
         {
             Deck.AddRange(Discards);
-            Deck.AddRange(Hand.Select(c => c.data));
+            Deck.AddRange(Hand.Select(c => c.Data));
 
             Discards.Clear();
             Hand.Clear();
@@ -74,10 +72,20 @@ namespace Cardevil.Cards
 
         public List<Card> SortedSelect => Selects.OrderBy(c => Hand.IndexOf(c)).ToList();
 
-        private bool AllValueSelected => Selects.All(c => c.data.CanUse);
+        private bool AllValueSelected => Selects.All(c => c.Data.CanUse);
 
 
 
+
+
+
+        public bool TryGetIndex(Card card, out int index)
+        {
+            index = -1;
+            if (card == null || Hand == null) return false;
+            index = Hand.IndexOf(card);
+            return index >= 0;
+        }
 
         public Card GetHandCard(int index) => Hand[index];
 
@@ -93,8 +101,9 @@ namespace Cardevil.Cards
             OnSelectsChaged?.Invoke(CardResultEvaluator.GetRanking(Selects));
         }
 
-        public void Swap(int indexA, int indexB)
+        public void Swap(Card a, int indexB)
         {
+            if (!TryGetIndex(a, out var indexA)) return;
             (Hand[indexA], Hand[indexB]) = (Hand[indexB], Hand[indexA]);
         }
 
@@ -107,7 +116,7 @@ namespace Cardevil.Cards
         {
             Hand.Remove(card);
             Selects.Remove(card);
-            Discards.Add(card.data);
+            Discards.Add(card.Data);
             card.Discard();
 
             OnSelectsChaged?.Invoke(HandRanking.None);
@@ -135,8 +144,8 @@ namespace Cardevil.Cards
 
                 // 숫자카드 정렬
                 .ThenBy(c => NumberSelectTypeRank(c))
-                .ThenBy(c => c.data.Number.NumberValue)
-                .ThenBy(c => c.data.Number.ColorValue)
+                .ThenBy(c => c.Data.Number.NumberValue)
+                .ThenBy(c => c.Data.Number.ColorValue)
 
                 .ToList();
         }
@@ -151,9 +160,9 @@ namespace Cardevil.Cards
                 .ThenBy(c => DirectionRank(c))
 
                 // 숫자카드 정렬
-                .ThenBy(c => c.data.Number.ColorValue)
+                .ThenBy(c => c.Data.Number.ColorValue)
                 .ThenBy(c => NumberSelectTypeRank(c))
-                .ThenBy(c => c.data.Number.NumberValue)
+                .ThenBy(c => c.Data.Number.NumberValue)
 
                 .ToList();
         }
@@ -199,44 +208,38 @@ namespace Cardevil.Cards
             return cardData;
         }
 
-        public void UpdateVisualIndex()
-        {
-            foreach (var card in Hand)
-                card.CardVisual.UpdateIndex();
-        }
-
         #region Sorting Helper
 
         private static int ValueTypeRank(Card c)
         {
-            return c.data.valueType == CardData.ValueType.Move ? 0 : 1;
+            return c.Data.valueType == CardData.ValueType.Move ? 0 : 1;
         }
 
         private static int MoveSelectTypeRank(Card c)
         {
-            if (c.data.selectType == CardData.SelectType.None || c.data.IsValueSelected)
+            if (c.Data.selectType == CardData.SelectType.None || c.Data.IsValueSelected)
                 return 0;
             else
-                return (int)c.data.selectType;
+                return (int)c.Data.selectType;
         }
 
         private static int NumberSelectTypeRank(Card c)
         {
-            if (c.data.selectType == CardData.SelectType.None
-                || (c.data.IsValueSelected && c.data.selectType == CardData.SelectType.Multiple))
+            if (c.Data.selectType == CardData.SelectType.None
+                || (c.Data.IsValueSelected && c.Data.selectType == CardData.SelectType.Multiple))
                 return -1;
-            else if (c.data.selectType == CardData.SelectType.All && c.data.IsValueSelected)
+            else if (c.Data.selectType == CardData.SelectType.All && c.Data.IsValueSelected)
                 return 0;
-            else if (c.data.selectType == CardData.SelectType.Multiple)
-                return c.data.NumberOptionCount;
-            else if (c.data.selectType == CardData.SelectType.All)
+            else if (c.Data.selectType == CardData.SelectType.Multiple)
+                return c.Data.NumberOptionCount;
+            else if (c.Data.selectType == CardData.SelectType.All)
                 return (int)CardData.SelectType.All;
             return 100;
         }
 
         private static int DirectionRank(Card c)
         {
-            return c.data.Move.DirectionValue switch
+            return c.Data.Move.DirectionValue switch
             {
                 Utils.Directions.Direction.Up => 0,
                 Utils.Directions.Direction.Down => 1,

--- a/Assets/Scripts/Utils/Util.cs
+++ b/Assets/Scripts/Utils/Util.cs
@@ -109,13 +109,5 @@ namespace Cardevil.Utils
             }
             return null;
         }
-        
-        /// <summary>
-        /// 카드가 Slot 안에서 몇 번째 위치인지 0~1 사이 값으로 정규화해 반환함
-        /// </summary>
-        public static float Remap(this float value, float from1, float to1, float from2, float to2)
-        {
-            return (value - from1) / (to1 - from1) * (to2 - from2) + from2;
-        }
     }
 }


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 FIX: 빠른 드래그 시 카드 시각적 순서 오류 수정 / 인덱스 관리 구조 개선

## 📑 개요
- 드래그 시 카드를 빠르게 이동할 경우 CardVisual의 시각적 순서가 정상적으로 갱신되지 않던 문제를 수정했습니다.
- 카드 인덱스 관리 로직 개선 / 스왑에 방어 로직을 추가로 빠른 연속 드래그에서도 정확한 순서 유지가 가능합니다.
---

## ✏️ 변경 사항

### 0) 전반적 변경
•	기존에 Card와 StageCardsCtx에 분산돼 있던 HandIndex 접근을 StageCardsCtx로 단일화.
•	Card 내부에서 직접 인덱스를 조회하지 않고, StageCardsCtx.TryGetIndex(...) / GetHandCard(...) 를 통해 인덱스를 일관되게 관리하도록 변경.

### 1) CardHandBar 스왑 로직 수정
•	DetectSwap()에서 Card.HandIndex 접근 대신 Ctx.TryGetIndex() 사용.
•	빠른 연속 드래그에서도 인덱스 오류 없이 스왑이 정확히 반영되도록 개선.

### 2) Card 구조 개선
•	Init() 메서드 오버로딩을 SpawnInHand(), SpawnAsReroll(), CompleteReroll()로 분리해 역할을 더 명확히 구분.
•      Card 내부의 HandIndex 제거 → StageCardsCtx.TryGetIndex() 기반으로 인덱스 계산.
•	이벤트 이름 정리(OnPointerDownEvent → PointerDown 등).

### 3) StageCardsContext 인덱스 관리
•	TryGetIndex(Card, out int) 메서드 추가 → 인덱스 탐색 시 null/범위 방어.

---

## ⭐ 특징 및 주의사항
•	빠른 드래그 환경에서 안정적 스왑 보장
•	인덱스 관리 책임이 명확히 StageCardsCtx에 집중


## ✅ 체크리스트
<!--
  해당 PR을 올리기 전에, 반드시 체크해야할 리스트입니다.
  [ ] : 체크안됨
  [x] : 체크됨
-->
- [x] Namespace 규칙 확인
- [x] public 함수의 경우 주석 확인
---
