### PR TITLE
feat: RandomUtil에 리스트 셔플 추가

### DIFF
--- a/Assets/Scripts/Utils/RandomUtil.cs
+++ b/Assets/Scripts/Utils/RandomUtil.cs
@@ -5,7 +5,7 @@ using URandom = UnityEngine.Random;
 
 namespace Cardevil.Utils
 {
-    public static partial class RandomUtil
+    public static class RandomUtil
     {
         public enum RandomType
         {
@@ -48,6 +48,24 @@ namespace Cardevil.Utils
             }
             return randoms[type].NextInt(min, max);
         }
+        
+        /// <summary>
+        /// <see cref="RandomType"/> 기반의 Fisher–Yates in place 셔플.  
+        /// </summary>
+        public static void ShuffleListInPlace<T>(this IList<T> list, RandomType type = RandomType.CardShuffle)
+        {
+            if (list == null) throw new ArgumentNullException(nameof(list));
+            
+            // Random Type의 초기화가 안 되어 있다면 초기화
+            if (!randoms.TryGetValue(type, out var r))
+                InitSeed(type);
+
+            for (int i = list.Count - 1; i > 0; i--)
+            {
+                int j = randoms[type].NextInt(0, i + 1);
+                (list[i], list[j]) = (list[j], list[i]);
+            }
+        }
 
         [Serializable]
         public class RandomSave
@@ -84,27 +102,6 @@ namespace Cardevil.Utils
                 InitSeed(save.type, save.initialSeed, save.state);
             }
             _isInitialized = true;
-        }
-    }
-
-    public static partial class RandomUtil
-    {
-        /// <summary>
-        /// <see cref="RandomType"/> 기반의 Fisher–Yates in place 셔플.  
-        /// </summary>
-        public static void ShuffleListInPlace<T>(this IList<T> list, RandomType type = RandomType.CardShuffle)
-        {
-            if (list == null) throw new ArgumentNullException(nameof(list));
-            
-            // Random Type의 초기화가 안 되어 있다면 초기화
-            if (!randoms.TryGetValue(type, out var r))
-                InitSeed(type);
-
-            for (int i = list.Count - 1; i > 0; i--)
-            {
-                int j = randoms[type].NextInt(0, i + 1);
-                (list[i], list[j]) = (list[j], list[i]);
-            }
         }
     }
 }

--- a/Assets/Scripts/Utils/RandomUtil.cs
+++ b/Assets/Scripts/Utils/RandomUtil.cs
@@ -1,12 +1,11 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using UMRandom = Unity.Mathematics.Random;
 using URandom = UnityEngine.Random;
 
 namespace Cardevil.Utils
 {
-    public static class RandomUtil
+    public static partial class RandomUtil
     {
         public enum RandomType
         {
@@ -85,6 +84,27 @@ namespace Cardevil.Utils
                 InitSeed(save.type, save.initialSeed, save.state);
             }
             _isInitialized = true;
+        }
+    }
+
+    public static partial class RandomUtil
+    {
+        /// <summary>
+        /// <see cref="RandomType"/> 기반의 Fisher–Yates in place 셔플.  
+        /// </summary>
+        public static void ShuffleListInPlace<T>(this IList<T> list, RandomType type = RandomType.CardShuffle)
+        {
+            if (list == null) throw new ArgumentNullException(nameof(list));
+            
+            // Random Type의 초기화가 안 되어 있다면 초기화
+            if (!randoms.TryGetValue(type, out var r))
+                InitSeed(type);
+
+            for (int i = list.Count - 1; i > 0; i--)
+            {
+                int j = randoms[type].NextInt(0, i + 1);
+                (list[i], list[j]) = (list[j], list[i]);
+            }
         }
     }
 }


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 FEAT: RandomUtil에 리스트 셔플 추가

## 📑 개요
<!--
   목적, 변경사항, 사용법에 대한 간략한 설명
   스크린샷이 포함될 수 있습니다.
-->
- CardDataFactory에서 사용하던 리스트 셔플 메서드를 기존의 RandomUtil 기반 로직으로 변경했습니다.
- Fisher–Yates Shuffle입니다.
---

## ✏️ 변경(추가) 사항

### 1) Random Util을 partial 클래스로 변경

---

## 📖사용 방법
<!--
  (Optional)
  다른 사람이 사용하지 않아도 되는 경우 없어도 됩니다.
-->
list.ShuffleListInPlace()로 list를 셔플할 수 있습니다. 

---

## ✅ 체크리스트
<!--
  해당 PR을 올리기 전에, 반드시 체크해야할 리스트입니다.
  [ ] : 체크안됨
  [x] : 체크됨
-->
- [x] Namespace 규칙 확인
---



