### PR TITLE
refactor: 카드 이벤트 구조 개선 및 구독 책임 정리

### DIFF
--- a/Assets/Scripts/Cards/InStage/CardPointerArgs.cs
+++ b/Assets/Scripts/Cards/InStage/CardPointerArgs.cs
@@ -1,16 +1,17 @@
+using System;
 using UnityEngine.UIElements;
 
 namespace Cardevil.Cards.InStage
 {
-    public readonly struct CardPointerArgs
+    public class CardPointerArgs : EventArgs
     {
-        public readonly float time;
-        public readonly MouseButton button;
+        public float Time { get; }
+        public MouseButton Button { get; } // TODO: 우클릭 감지 필요없음. 없앨 예정.
 
         public CardPointerArgs(float time, MouseButton button)
         {
-            this.time = time;
-            this.button = button;
+            Time = time;
+            Button = button;
         }
     }
 }

--- a/Assets/Scripts/Cards/InStage/Presenter/Card.cs
+++ b/Assets/Scripts/Cards/InStage/Presenter/Card.cs
@@ -32,8 +32,6 @@ namespace Cardevil.Cards.InStage.Presenter
         public event Action<Card, CardPointerArgs> PointerDown, PointerUp;
         public Action<Card> ValueSelectionStarted, ValueSelectionEnded; // TODO: 외부에서 호출되지 않도록 메서드로 감싸기
 
-        public Action RerollDrawn, RerollEnded;
-        public event Action<Transform> RerollDiscarded;
         public Action Drawn; 
         
         private Poolable _poolable;
@@ -105,8 +103,10 @@ namespace Cardevil.Cards.InStage.Presenter
         public void SetRerollState(bool value)
         {
             state.isReroll = value;
-            if (!value) RerollEnded?.Invoke();
+            // if (!value) RerollEnded?.Invoke();
+            if (!value) visual.EndReroll();
         }
+        
         
         public void UpdatePosition()
         {
@@ -122,11 +122,17 @@ namespace Cardevil.Cards.InStage.Presenter
             Discarded?.Invoke();
             Managers.Resource.Destroy(gameObject);
         }
+
+        public void DoRerollDraw()
+        {
+            visual.AnimateRerollDraw();
+        }
         
-        public void RerollDiscard(Transform target)
+        public void DoRerollDiscard()
         {
             state.isReroll = true;
-            RerollDiscarded?.Invoke(target);
+            // RerollDiscarded?.Invoke(target);
+            visual.AnimateRerollDiscard();
             Managers.Resource.Destroy(gameObject);
         }
 

--- a/Assets/Scripts/Cards/InStage/Presenter/Card.cs
+++ b/Assets/Scripts/Cards/InStage/Presenter/Card.cs
@@ -1,6 +1,5 @@
 using Cardevil.Attributes;
 using Cardevil.Cards.Data.InStage;
-using Cardevil.Cards.Data.Modifiers;
 using Cardevil.Cards.Evaluations;
 using Cardevil.Cards.InStage.Model.ReadOnly;
 using Cardevil.Cards.InStage.View;
@@ -18,7 +17,8 @@ namespace Cardevil.Cards.InStage.Presenter
 {
     [RequireComponent(typeof(Poolable))]
     public class Card : MonoBehaviour, IEvaluateVisual, IClearable,
-                        IDragHandler, IBeginDragHandler, IEndDragHandler, IPointerEnterHandler, IPointerExitHandler, IPointerUpHandler, IPointerDownHandler
+                        IDragHandler, IBeginDragHandler, IEndDragHandler, 
+                        IPointerEnterHandler, IPointerExitHandler, IPointerUpHandler, IPointerDownHandler
     {
         [Header("SO")]
         [SerializeField] private CardVisualSettingSO visualSetting;
@@ -28,15 +28,14 @@ namespace Cardevil.Cards.InStage.Presenter
         [SerializeField, VisibleOnly] private CardVisual visual;
         [SerializeField, VisibleOnly] private CardState state;
         
-        public event Action DragStarted, DragEnded, Discarded;
-        public event Action<Card, CardPointerArgs> PointerDown, PointerUp;
-        public Action<Card> ValueSelectionStarted, ValueSelectionEnded; // TODO: 외부에서 호출되지 않도록 메서드로 감싸기
-
-        public Action Drawn; 
+        private event Action DragStart, DragEnd;
+        private event Action<Card, CardPointerArgs> PointerDown, PointerUp;
         
         private Poolable _poolable;
         private IReadOnlyStageCardsModel _model;
-        
+
+        #region Property
+
         public CardData Data => data;
         public bool IsDragging => state.isDragging;
         public bool IsReroll => state.isReroll;
@@ -52,19 +51,17 @@ namespace Cardevil.Cards.InStage.Presenter
             }
         }
 
+        #endregion
+        
+        #region Unity Event
+
         private void Awake()
         {
             Clear();
             _poolable = GetComponent<Poolable>();
             _poolable.OnRelease += Clear;
         }
-
-        public void Clear()
-        {
-            state = new CardState();
-            visual = null;
-        }
-
+        
         private void Update()
         {
             if (state.isDiscarded) return;
@@ -81,14 +78,22 @@ namespace Cardevil.Cards.InStage.Presenter
                 transform.Translate(velocity * Time.deltaTime);
             }
         }
-        
+
+        #endregion
+
+        #region Initialization
+
         /// <summary>
-        /// 주어진 데이터를 바탕으로 초기화.
-        /// Visual도 함께 생성.
+        /// 카드 데이터 및 비주얼 초기화.
+        /// 지정된 <see cref="CardData"/>와 <see cref="CardVisualSpriteSet"/>을 기반으로
+        /// 카드 오브젝트 생성 및 비주얼 요소 설정.
         /// </summary>
-        public void Init(CardData data, CardVisualSpriteSet visualSpriteSet, IReadOnlyStageCardsModel model)
+        /// <param name="cardData">카드 데이터 객체</param>
+        /// <param name="visualSpriteSet">비주얼 스프라이트 세트</param>
+        /// <param name="model">스테이지 카드 모델 참조용 읽기 전용 모델</param>
+        public void Init(CardData cardData, CardVisualSpriteSet visualSpriteSet, IReadOnlyStageCardsModel model)
         {
-            this.data = data;
+            data = cardData;
             _model = model;
             
             // Card Visual
@@ -98,47 +103,91 @@ namespace Cardevil.Cards.InStage.Presenter
             var go = Managers.Resource.Instantiate("Cards/CardVisual", visualHandler.transform);
             visual = go.GetComponent<CardVisual>();
             visual.Init(this, visualSpriteSet, model);
+            WireVisual(visual);
         }
 
+        public void Clear()
+        {
+            state = new CardState();
+            visual = null;
+        }
+
+        #endregion
+        
+        #region Reroll
+
+        /// <summary>
+        /// 리롤 상태 설정.
+        /// 지정된 값에 따라 리롤 상태를 갱신하고, 해제 시 비주얼 종료 처리.
+        /// </summary>
+        /// <param name="value">리롤 상태 값</param>
         public void SetRerollState(bool value)
         {
             state.isReroll = value;
-            // if (!value) RerollEnded?.Invoke();
-            if (!value) visual.EndReroll();
+            if (!value) 
+                visual.EndReroll();
         }
         
+        /// <summary>
+        /// 리롤 드로우 애니메이션 실행.
+        /// 비주얼 연출 수행.
+        /// </summary>
+        public void DoRerollDraw()
+        {
+            visual.AnimateRerollDraw();
+        }
         
+        /// <summary>
+        /// (리롤) 버리기 처리.
+        /// 리롤 상태 설정 후 버리기 애니메이션 실행 및 카드 오브젝트 풀에 반환.
+        /// </summary>
+        public void DoRerollDiscard()
+        {
+            state.isReroll = true;
+            visual.AnimateRerollDiscard();
+            Managers.Resource.Destroy(gameObject);
+        }
+
+        #endregion
+
+        #region Draw/Discard
+
+        /// <summary>
+        /// 뽑기 애니메이션 실행.
+        /// </summary>
+        public void DoDraw()
+        {
+            visual.AnimateDraw();
+        }
+        
+        /// <summary>
+        /// 버리기 처리.
+        /// 카드 버리기 상태 설정 후 비주얼 해제 및 오브젝트 풀에 반환.
+        /// </summary>
+        public void DoDiscard()
+        {
+            state.isDiscarded = true;
+            
+            UnwireVisual(visual);
+            visual.Discard();
+            
+            Managers.Resource.Destroy(gameObject);
+        }
+
+        #endregion
+
+        #region Presenter
+
+        /// <summary>
+        /// 카드 위치 갱신.
+        /// 선택 및 드래그 상태에 따라 로컬 위치 조정.
+        /// </summary>
         public void UpdatePosition()
         {
             if (state.isDragging) return;
 
             float newY = state.isSelected ? visualSetting.SelectOffset : 0;
             transform.localPosition = new Vector3(0, newY, 0);
-        }
-
-        public void Discard()
-        {
-            state.isDiscarded = true;
-            Discarded?.Invoke();
-            Managers.Resource.Destroy(gameObject);
-        }
-
-        public void DoRerollDraw()
-        {
-            visual.AnimateRerollDraw();
-        }
-        
-        public void DoRerollDiscard()
-        {
-            state.isReroll = true;
-            // RerollDiscarded?.Invoke(target);
-            visual.AnimateRerollDiscard();
-            Managers.Resource.Destroy(gameObject);
-        }
-
-        public void ExecuteEvaluationAction()
-        {
-            visual.ExecuteEvaluationAction();
         }
         
         /// <summary>
@@ -150,7 +199,11 @@ namespace Cardevil.Cards.InStage.Presenter
             float newY = value ? visualSetting.SelectOffset : 0;
             transform.localPosition = new Vector3(0, newY, 0);
         }
-
+        
+        /// <summary>
+        /// 전체 카드 드래그 상태 설정.
+        /// 다른 카드의 드래그 여부를 표시하는 상태 값 지정.
+        /// </summary>
         public void SetAnyCardDragged(bool value)
         {
             state.isAnyCardDragged = value;
@@ -165,9 +218,53 @@ namespace Cardevil.Cards.InStage.Presenter
         {
             visual?.UpdateVisualIndex();
         }
+        
+        #endregion
+        
+        public void ExecuteEvaluationAction()
+        {
+            visual.ExecuteEvaluationAction();
+        }
 
+        #region Wire
 
-        #region Point Event
+        public void AddDragStart(Action h) => DragStart += h;
+        public void RemoveDragStart(Action h) => DragStart -= h;
+        
+        public void AddDragEnd(Action h) => DragEnd += h;
+        public void RemoveDragEnd(Action h) => DragEnd -= h;
+
+        public void AddPointerDown(Action<Card, CardPointerArgs> h) => PointerDown += h;
+        public void RemovePointerDown(Action<Card, CardPointerArgs> h) => PointerDown -= h;
+
+        public void AddPointerUp(Action<Card, CardPointerArgs> h) => PointerUp += h;
+        public void RemovePointerUp(Action<Card, CardPointerArgs> h) => PointerUp -= h;
+        
+        private void WireVisual(CardVisual cardVisual)
+        {
+            if (!cardVisual) return;
+            
+            DragStart += cardVisual.OnDragStart;
+            DragEnd += cardVisual.OnDragEnd;
+
+            PointerDown += cardVisual.OnPointerDown;
+            PointerUp += cardVisual.OnPointerUp;
+        }
+
+        private void UnwireVisual(CardVisual cardVisual)
+        {
+            if (!cardVisual) return;
+            
+            DragStart -= cardVisual.OnDragStart;
+            DragEnd -= cardVisual.OnDragEnd;
+            
+            PointerDown -= cardVisual.OnPointerDown;
+            PointerUp -= cardVisual.OnPointerUp;
+        }
+        
+        #endregion
+
+        #region Pointer Event Interfaces
 
         public void OnPointerEnter(PointerEventData eventData)
         {
@@ -202,7 +299,7 @@ namespace Cardevil.Cards.InStage.Presenter
             
                 // TODO: 실행자 수정
                 // _handBar.selectContainer.OpenSelection(this);
-                ValueSelectionStarted?.Invoke(this);
+                // ValueSelectionStarted?.Invoke(this);
             }
         }
 
@@ -214,7 +311,7 @@ namespace Cardevil.Cards.InStage.Presenter
             if (!CanInteraction)
                 return;
 
-            DragStarted?.Invoke();
+            DragStart?.Invoke();
             state.isDragging = true;
         }
 
@@ -230,7 +327,7 @@ namespace Cardevil.Cards.InStage.Presenter
             if (!CanInteraction)
                 return;
 
-            DragEnded?.Invoke();
+            DragEnd?.Invoke();
             transform.DOLocalMove(
                     endValue: state.isSelected
                         ? new Vector3(0, visualSetting.SelectOffset, 0)

--- a/Assets/Scripts/Cards/InStage/Presenter/RerollPresenter.cs
+++ b/Assets/Scripts/Cards/InStage/Presenter/RerollPresenter.cs
@@ -169,7 +169,7 @@ namespace Cardevil.Cards.InStage.Presenter
                 // 버리기 Tween
                 foreach (var card in _model.Hand)
                 {
-                    card.RerollDiscard(_view.DeckVisual.Front);
+                    card.DoRerollDiscard();
                     await UniTask.Delay(TimeSpan.FromSeconds(discard));
                 }
 
@@ -181,7 +181,7 @@ namespace Cardevil.Cards.InStage.Presenter
                 for (int i = 0; i < _maxHand; i++)
                 {
                     var card = Spawn();
-                    card.RerollDrawn?.Invoke();
+                    card.DoRerollDraw();
                     await UniTask.Delay(TimeSpan.FromSeconds(draw));
                 }
 

--- a/Assets/Scripts/Cards/InStage/Presenter/StageCardsPresenter.cs
+++ b/Assets/Scripts/Cards/InStage/Presenter/StageCardsPresenter.cs
@@ -99,7 +99,7 @@ namespace Cardevil.Cards.InStage.Presenter
             // 현재 생성된 카드 모두 HandBar 슬롯으로 이동
             foreach (var card in _model.Hand)
             {
-                AddListeners(card);
+                WireCard(card);
                 HandChanged += card.OnHandChanged;
                 card.SetRerollState(false);
                 _model.TryGetIndex(card, out int index);
@@ -166,7 +166,7 @@ namespace Cardevil.Cards.InStage.Presenter
             }
         }
         
-        private void AddListeners(Card card)
+        private void WireCard(Card card)
         {
             card.PointerDown += OnCardPointerDown;
             card.PointerUp += OnCardPointerUp;
@@ -224,7 +224,7 @@ namespace Cardevil.Cards.InStage.Presenter
             if (!_state.canInteract) return;
             
             _state.activateCard = card;
-            _state.pointerDownTime = args.time;
+            _state.pointerDownTime = args.Time;
         }
 
         // 카드가 선택 가능 상태면 선택,
@@ -234,11 +234,11 @@ namespace Cardevil.Cards.InStage.Presenter
             if (!_state.canInteract) return;
             
             if (_state.activateCard != card) return;
-            if (args.time - _state.pointerDownTime > _visualSetting.ClickDetectThreshold) return;
+            if (args.Time - _state.pointerDownTime > _visualSetting.ClickDetectThreshold) return;
             _state.activateCard = null;
             
             // 좌클릭 처리
-            if (args.button == MouseButton.LeftMouse)
+            if (args.Button == MouseButton.LeftMouse)
             {
                 if (_model.Selection.Contains(card))
                 {
@@ -261,7 +261,7 @@ namespace Cardevil.Cards.InStage.Presenter
             
             // 우클릭 처리
             // TODO: 우클릭 관련 로직 추후 '전환 버튼'으로 이동
-            else if (args.button == MouseButton.RightMouse)
+            else if (args.Button == MouseButton.RightMouse)
             {
                 // if (!card.Data.CanOpenSelection) return;
                 
@@ -448,7 +448,7 @@ namespace Cardevil.Cards.InStage.Presenter
             card.Init(cardData, spriteSet, _model);
 
             // 이벤트 구독
-            AddListeners(card);
+            WireCard(card);
             HandChanged += card.OnHandChanged;
 
             _model.Draw(card);

--- a/Assets/Scripts/Cards/InStage/Presenter/StageCardsPresenter.cs
+++ b/Assets/Scripts/Cards/InStage/Presenter/StageCardsPresenter.cs
@@ -35,6 +35,8 @@ namespace Cardevil.Cards.InStage.Presenter
         
         private bool CanInput => _state is { isSwapping: false, canInteract: true };
 
+        #region Initialization
+
         /// <summary>
         /// StageCardsPresenter 초기화.  
         /// model 참조를 저장, 카드 시각 효과 설정용 So를 로드.  
@@ -126,33 +128,6 @@ namespace Cardevil.Cards.InStage.Presenter
             _updateCts = new();
             UpdateAsync(_updateCts.Token).Forget();
         }
-
-        /// <summary>
-        /// 스테이지가 종료된 후 UI를 비활성화, 
-        /// 내부 업데이트 루프를 정지시킵니다.
-        /// </summary>
-        /// <returns>UI 비활성화 후 완료되는 <see cref="UniTask"/></returns>
-        public async UniTask Exit()
-        {
-            // Update Async 정지
-            _updateCts.Cancel();
-            
-            await _view.ExitHandBarAsync();
-        }
-
-        /// <summary>
-        /// Presenter의 내부 상태를 초기화합니다.  
-        /// 상호작용 가능 여부를 비활성화하고, View를 파괴합니다.
-        /// </summary>
-        public void Clear()
-        {
-            _state.canInteract = false;
-            UpdateUI();
-            
-            if (!_view) return;
-            _view.Clear();
-            Managers.Resource.Destroy(_view.gameObject);
-        }
         
         // MonoBehaviour의 Update()를 대체
         private async UniTask UpdateAsync(CancellationToken token)
@@ -166,30 +141,64 @@ namespace Cardevil.Cards.InStage.Presenter
             }
         }
         
+        #endregion
+
+        #region Clear
+
+        /// <summary>
+        /// 스테이지가 종료된 후 UI를 비활성화, 
+        /// 내부 업데이트 루프를 정지시킵니다.
+        /// </summary>
+        /// <returns>UI 비활성화 후 완료되는 <see cref="UniTask"/></returns>
+        public async UniTask Exit()
+        {
+            // Update Async 정지
+            _updateCts.Cancel();
+            
+            await _view.ExitHandBarAsync();
+        }
+        
+        /// <summary>
+        /// Presenter의 내부 상태를 초기화합니다.  
+        /// 상호작용 가능 여부를 비활성화하고, View를 파괴합니다.
+        /// </summary>
+        public void Clear()
+        {
+            _state.canInteract = false;
+            UpdateUI();
+            
+            if (!_view) return;
+            _view.Clear();
+            Managers.Resource.Destroy(_view.gameObject);
+        }
+
+        #endregion
+        
+        #region Wire
+
         private void WireCard(Card card)
         {
-            card.PointerDown += OnCardPointerDown;
-            card.PointerUp += OnCardPointerUp;
-            card.DragStarted += BeginDrag;
-            card.DragEnded += EndDrag;
-            card.ValueSelectionEnded += OnSelectValueEnd;
+            card.AddDragStart(OnDragStarted);
+            card.AddDragEnd(OnDragEnded);
+            
+            card.AddPointerDown(OnPointerDown);
+            card.AddPointerUp(OnPointerUp);
+            
+            // card.ValueSelectionEnded += OnSelectValueEnd;
         }
         
-        private void RemoveListeners(Card card)
+        private void UnwireCard(Card card)
         {
-            card.PointerDown -= OnCardPointerDown;
-            card.PointerUp -= OnCardPointerUp;
-            card.DragStarted -= BeginDrag;
-            card.DragEnded -= EndDrag;
-            card.ValueSelectionEnded -= OnSelectValueEnd;
+            card.RemoveDragStart(OnDragStarted);
+            card.RemoveDragEnd(OnDragEnded);
+            
+            card.RemovePointerDown(OnPointerDown);
+            card.RemovePointerUp(OnPointerUp);
+
+            // card.ValueSelectionEnded -= OnSelectValueEnd;
         }
-        
-        // 플레이어 턴이면서 카드 값 선택이 바뀔 때.
-        // Card.onselectEnded에서 호출
-        private void OnSelectValueEnd(Card _)
-        {
-            UpdateUI();
-        }
+
+        #endregion
         
         #region ITurnPlayerInput
 
@@ -218,8 +227,25 @@ namespace Cardevil.Cards.InStage.Presenter
         
         #region Card Events
         
+        private void OnDragStarted()
+        {
+            _state.draggedCard = _state.activateCard;
+            _state.activateCard = null;
+            
+            foreach (var card in _model.Hand) card.SetAnyCardDragged(true);
+            UpdateUI();
+        }
+
+        private void OnDragEnded()
+        {
+            _state.draggedCard = null;
+            
+            foreach (var card in _model.Hand) card.SetAnyCardDragged(false);
+            UpdateUI();
+        }
+        
         // 카드 클릭 상태를 기록
-        private void OnCardPointerDown(Card card, CardPointerArgs args)
+        private void OnPointerDown(Card card, CardPointerArgs args)
         {
             if (!_state.canInteract) return;
             
@@ -229,7 +255,7 @@ namespace Cardevil.Cards.InStage.Presenter
 
         // 카드가 선택 가능 상태면 선택,
         // 이미 선택된 상태면 선택 해제를 함
-        private void OnCardPointerUp(Card card, CardPointerArgs args)
+        private void OnPointerUp(Card card, CardPointerArgs args)
         {
             if (!_state.canInteract) return;
             
@@ -273,22 +299,7 @@ namespace Cardevil.Cards.InStage.Presenter
             }
         }
         
-        private void BeginDrag()
-        {
-            _state.draggedCard = _state.activateCard;
-            _state.activateCard = null;
-            
-            foreach (var card in _model.Hand) card.SetAnyCardDragged(true);
-            UpdateUI();
-        }
 
-        private void EndDrag()
-        {
-            _state.draggedCard = null;
-            
-            foreach (var card in _model.Hand) card.SetAnyCardDragged(false);
-            UpdateUI();
-        }
 
         #endregion
         
@@ -384,10 +395,10 @@ namespace Cardevil.Cards.InStage.Presenter
             {
                 _model.TryGetIndex(card, out var index);
                 
-                RemoveListeners(card);
+                UnwireCard(card);
                 _model.Discard(card);
                 HandChanged?.Invoke();
-                card.Discard();
+                card.DoDiscard();
                 
                 // slot 비활성화
                 _view.SetSlotActive(false, index, _model.Hand.Count);
@@ -411,7 +422,7 @@ namespace Cardevil.Cards.InStage.Presenter
                 // 슬롯 활성화
                 var card = Spawn();
                 _view.SetSlotActive(true, indexFactor + i, _model.Hand.Count);
-                card.Drawn?.Invoke();
+                card.DoDraw();
                 await UniTask.Delay(TimeSpan.FromSeconds(_visualSetting.DrawInterval));
             }
 
@@ -434,8 +445,6 @@ namespace Cardevil.Cards.InStage.Presenter
 
         #endregion
         
-        // Spawn
-        // - - - - - - - - - - -
         private Card Spawn()
         {
             var cardData = _model.PopCard();
@@ -488,22 +497,6 @@ namespace Cardevil.Cards.InStage.Presenter
             var viewState = new StageCardsViewState(canUse, canDiscard, true, _model.Deck.Count, _model.DiscardRemain);
             _view.UpdateUI(viewState);
         }
-        
-        public async UniTask Revive(int amount)
-        {
-            amount = Mathf.Min(amount, _model.DiscardPile.Count);
-            for (int i = 0; i < amount; i++)
-            {
-                // var dummyCard = Instantiate(dummyCardVisual, parent: deck.Front.transform);
-                // dummyCard.transform.SetSiblingIndex(1);
-                // var tween = dummyCard.transform.DOLocalMove(new Vector3(0, 0), visualSetting.ReviveInterval)
-                //                             .SetEase(Ease.OutCubic);
-                // await tween.AsyncWaitForCompletion();
-                // Destroy(dummyCard);
-                // _ctx.Revive();
-                // UpdateUI();
-            }
-        }
 
         #region nested
 
@@ -520,5 +513,30 @@ namespace Cardevil.Cards.InStage.Presenter
         }
 
         #endregion
+        
+        // 이동해야할 로직들
+        // - - - - - - - - - 
+        public async UniTask Revive(int amount)
+        {
+            amount = Mathf.Min(amount, _model.DiscardPile.Count);
+            for (int i = 0; i < amount; i++)
+            {
+                // var dummyCard = Instantiate(dummyCardVisual, parent: deck.Front.transform);
+                // dummyCard.transform.SetSiblingIndex(1);
+                // var tween = dummyCard.transform.DOLocalMove(new Vector3(0, 0), visualSetting.ReviveInterval)
+                //                             .SetEase(Ease.OutCubic);
+                // await tween.AsyncWaitForCompletion();
+                // Destroy(dummyCard);
+                // _ctx.Revive();
+                // UpdateUI();
+            }
+        }
+        
+        // 플레이어 턴이면서 카드 값 선택이 바뀔 때.
+        // Card.onselectEnded에서 호출
+        private void OnSelectValueEnd(Card _)
+        {
+            UpdateUI();
+        }
     }
 }

--- a/Assets/Scripts/Cards/InStage/SelectContainer.cs
+++ b/Assets/Scripts/Cards/InStage/SelectContainer.cs
@@ -123,8 +123,8 @@ namespace Cardevil.Cards.InStage
         {
             backgroundButton.gameObject.SetActive(value);
             gameObject.SetActive(value);
-            if (!value)
-                card.ValueSelectionEnded?.Invoke(card);
+            // if (!value)
+            //     card.ValueSelectionEnded?.Invoke(card);
         }
     }
 }

--- a/Assets/Scripts/Cards/InStage/View/CardVisual.cs
+++ b/Assets/Scripts/Cards/InStage/View/CardVisual.cs
@@ -40,6 +40,8 @@ namespace Cardevil.Cards.InStage.View
         private VisualTransformDelta _delta;
         private VisualState _state;
 
+        #region Unity Event
+
         private void Awake()
         {
             _canvas = GetComponent<Canvas>();
@@ -48,63 +50,7 @@ namespace Cardevil.Cards.InStage.View
             _poolable = GetComponent<Poolable>();
             _poolable.OnRelease += Clear;
         }
-
-        public void Clear()
-        {
-            RemoveAllEvents();
-
-            frontImage.rectTransform.rotation = Quaternion.Euler(0f, 90f, 0f);
-            backImage.rectTransform.rotation = Quaternion.Euler(0f, 0f, 0f);
-            shakeObject.localEulerAngles = Vector3.zero;
-
-            _canvas.overrideSorting = false;
-            _state.isDiscarded = false;
-            _state.isInitialized = false;
-        }
-
-        private void RemoveAllEvents()
-        {
-            if (parentCard)
-            {
-                UnsubscribeFromParent(parentCard);
-                parentCard = null;
-            }
-
-            if (_model != null)
-            {
-                // _model.HandChanged -= UpdateIndex;
-            }
-
-            parentCard = null;
-            _model = null;
-        }
-
-        public void Init(Card parentCard, CardVisualSpriteSet visualSpriteSet, IReadOnlyStageCardsModel model)
-        {
-            if (_state.isInitialized) return;
-            
-            this.parentCard = parentCard;
-            _model = model;
-            
-            // Subscribe Events
-            SubscribeToParent(parentCard);
-            // _model.HandChanged += UpdateIndex;
-            
-            _canvas.overrideSorting = false; // @PoolableRoot로 갈 때 자동으로 overrideSorting = true가 됨.
-            // UpdateVisual();
-            frontImage.sprite = visualSpriteSet.FrontBackgroundImage;
-            numberImages[0].sprite = visualSpriteSet.FrontNumberImage;
-            numberImages[0].gameObject.SetActive(visualSpriteSet.FrontNumberImage);
-            
-            var deckVisuals = FindObjectsByType<CardDeckVisual>(FindObjectsSortMode.None);
-            if (deckVisuals == null || deckVisuals.Length == 0) { LogEx.LogError("씬 내에 Deck Visual이 존재하지 않음!"); return; }
-            _deckVisual = deckVisuals[0];
-
-            transform.position = _deckVisual.Front.position;
-
-            _state.isInitialized = true;
-        }
-
+        
         private void Update()
         {
             if (!_state.isInitialized || !parentCard || _state.isDiscarded)
@@ -116,8 +62,6 @@ namespace Cardevil.Cards.InStage.View
             ApplyCurveTilt();
         }
         
-        #region Update
-
         /// <summary>
         /// 카드 비주얼의 월드 위치를 부모 카드 위치로 부드럽게 보간해 따라감.
         /// 드래그 중에는 곡선 수직 오프셋을 적용하지 않음.
@@ -196,46 +140,65 @@ namespace Cardevil.Cards.InStage.View
 
             shakeObject.localEulerAngles = new Vector3(0f, 0f, nextZ);
         }
-        
-        #endregion
-        
-        #region Subscribe
-
-        private void SubscribeToParent(Card p)
-        {
-            if (!p) return;
-
-            p.PointerDown += OnPointerDown;
-            p.PointerUp += OnPointerUp;
-            p.DragStarted += OnBeginDrag;
-            p.DragEnded += OnEndDrag;
-            p.ValueSelectionStarted += OnSelectStarted;
-            p.ValueSelectionEnded += OnSelectEnded;
-            
-            p.Drawn += OnDraw;
-            p.Discarded += OnDiscard;
-        }
-
-        private void UnsubscribeFromParent(Card p)
-        {
-            if (!p) return;
-
-            p.PointerDown -= OnPointerDown;
-            p.PointerUp -= OnPointerUp;
-            p.DragStarted -= OnBeginDrag;
-            p.DragEnded -= OnEndDrag;
-            p.ValueSelectionStarted -= OnSelectStarted;
-            p.ValueSelectionEnded -= OnSelectEnded;
-            
-            p.Drawn -= OnDraw;
-            p.Discarded -= OnDiscard;
-        }
 
         #endregion
 
-        #region Pointer Event
+        #region Initialization
 
-        private void OnPointerDown(Card _, CardPointerArgs args)
+        public void Init(Card parentCard, CardVisualSpriteSet visualSpriteSet, IReadOnlyStageCardsModel model)
+        {
+            if (_state.isInitialized) return;
+            
+            this.parentCard = parentCard;
+            _model = model;
+            
+            // Subscribe Events
+            // SubscribeToParent(parentCard);
+            // _model.HandChanged += UpdateIndex;
+            
+            _canvas.overrideSorting = false; // @PoolableRoot로 갈 때 자동으로 overrideSorting = true가 됨.
+            // UpdateVisual();
+            frontImage.sprite = visualSpriteSet.FrontBackgroundImage;
+            numberImages[0].sprite = visualSpriteSet.FrontNumberImage;
+            numberImages[0].gameObject.SetActive(visualSpriteSet.FrontNumberImage);
+            
+            var deckVisuals = FindObjectsByType<CardDeckVisual>(FindObjectsSortMode.None);
+            if (deckVisuals == null || deckVisuals.Length == 0) { LogEx.LogError("씬 내에 Deck Visual이 존재하지 않음!"); return; }
+            _deckVisual = deckVisuals[0];
+
+            transform.position = _deckVisual.Front.position;
+
+            _state.isInitialized = true;
+        }
+        
+        public void Clear()
+        {
+            parentCard = null;
+
+            frontImage.rectTransform.rotation = Quaternion.Euler(0f, 90f, 0f);
+            backImage.rectTransform.rotation = Quaternion.Euler(0f, 0f, 0f);
+            shakeObject.localEulerAngles = Vector3.zero;
+
+            _canvas.overrideSorting = false;
+            _state.isDiscarded = false;
+            _state.isInitialized = false;
+        }
+
+        #endregion
+        
+        #region Pointer Event Handler
+        
+        public void OnDragStart()
+        {
+            _canvas.overrideSorting = true;
+        }
+
+        public void OnDragEnd()
+        {
+            _canvas.overrideSorting = false;
+        }
+
+        public void OnPointerDown(Card _, CardPointerArgs args)
         {
             transform.DOScale(endValue: visualSetting.SelectScale, duration: visualSetting.SelectScaleTweenDuration)
                 .SetEase(visualSetting.SelectScaleEase);
@@ -243,54 +206,43 @@ namespace Cardevil.Cards.InStage.View
             shadowTransform.localPosition += -Vector3.up * visualSetting.ShadowOffset;
         }
 
-        private void OnPointerUp(Card _, CardPointerArgs args)
+        public void OnPointerUp(Card _, CardPointerArgs args)
         {
             transform.DOScale(endValue: 1f, duration: visualSetting.SelectScaleTweenDuration)
                 .SetEase(visualSetting.SelectScaleEase);
 
             shadowTransform.localPosition = _delta.shadowOriginPosition;
         }
-
-        private void OnBeginDrag()
-        {
-            _canvas.overrideSorting = true;
-        }
-
-        private void OnEndDrag()
-        {
-            _canvas.overrideSorting = false;
-        }
-
+        
         #endregion
 
-        #region Draw/Discard Event
+        #region Reroll
 
         public void AnimateRerollDraw()
         {
             _deckVisual.OnInteraction();
             transform.DOMove(endValue: parentCard.transform.position, visualSetting.RerollDrawDuration)
-                        .SetEase(visualSetting.RerollDrawEase);
+                .SetEase(visualSetting.RerollDrawEase);
 
             var sequence = DOTween.Sequence();
             sequence.Append(backImage.transform.DOLocalRotate(new Vector3(0, 90, 0), visualSetting.RerollFlipDuration * visualSetting.RerollFlipBackImageRatio)
-                        .SetEase(visualSetting.FlipEase));
+                .SetEase(visualSetting.FlipEase));
             sequence.Append(frontImage.transform.DOLocalRotate(new Vector3(0, 0, 0), visualSetting.RerollFlipDuration * visualSetting.RerollFlipFrontImageRation)
-                        .SetEase(visualSetting.FlipEase));
+                .SetEase(visualSetting.FlipEase));
         }
 
         public void AnimateRerollDiscard()
         {
             _state.isDiscarded = true;
-            RemoveAllEvents();
 
             var tween = transform.DOMove(endValue: _deckVisual.Front.position, visualSetting.RerollDiscardDuration)
-                        .SetEase(visualSetting.RerollDiscardEase);
+                .SetEase(visualSetting.RerollDiscardEase);
 
             var sequence = DOTween.Sequence();
             sequence.Append(frontImage.transform.DOLocalRotate(new Vector3(0, 90, 0), visualSetting.RerollFlipDuration * .5f)
-                        .SetEase(visualSetting.FlipEase));
+                .SetEase(visualSetting.FlipEase));
             sequence.Append(backImage.transform.DOLocalRotate(new Vector3(0, 0, 0), visualSetting.RerollFlipDuration * .5f)
-                        .SetEase(visualSetting.FlipEase));
+                .SetEase(visualSetting.FlipEase));
 
             tween.OnComplete(() =>
             {
@@ -304,7 +256,11 @@ namespace Cardevil.Cards.InStage.View
             _canvas.overrideSorting = false;
         }
 
-        private void OnDraw()
+        #endregion
+
+        #region Draw/Discard
+
+        public void AnimateDraw()
         {
             _deckVisual.OnInteraction();
 
@@ -315,11 +271,10 @@ namespace Cardevil.Cards.InStage.View
                         .SetEase(visualSetting.FlipEase));
         }
 
-        private void OnDiscard()
+        public void Discard()
         {
             _state.isDiscarded = true;
             _canvas.overrideSorting = true;
-            RemoveAllEvents();
 
             var tween = transform.DOLocalMove(endValue: new Vector3(1050, 0, 0), visualSetting.DiscardDuration)
                         .SetEase(visualSetting.DiscardEase);
@@ -327,6 +282,8 @@ namespace Cardevil.Cards.InStage.View
         }
 
         #endregion
+
+        #region Visual Index
 
         public void UpdateVisualIndex()
         {
@@ -338,6 +295,8 @@ namespace Cardevil.Cards.InStage.View
                 transform.SetSiblingIndex(index);
             }
         }
+
+        #endregion
         
         private void Destroy()
         {
@@ -357,7 +316,6 @@ namespace Cardevil.Cards.InStage.View
             // TODO: 값 선택 후 다시 visual sprite set 생성. Card가 생성 후 넘겨줌.
         }
         
-
         public void ExecuteEvaluationAction()
         {
             transform.DOShakePosition(.6f, 50);

--- a/Assets/Scripts/Cards/InStage/View/CardVisual.cs
+++ b/Assets/Scripts/Cards/InStage/View/CardVisual.cs
@@ -211,10 +211,7 @@ namespace Cardevil.Cards.InStage.View
             p.DragEnded += OnEndDrag;
             p.ValueSelectionStarted += OnSelectStarted;
             p.ValueSelectionEnded += OnSelectEnded;
-
-            p.RerollDrawn += OnRerollDraw;
-            p.RerollDiscarded += OnRerollDiscard;
-            p.RerollEnded += OnRerollEnd;
+            
             p.Drawn += OnDraw;
             p.Discarded += OnDiscard;
         }
@@ -229,10 +226,7 @@ namespace Cardevil.Cards.InStage.View
             p.DragEnded -= OnEndDrag;
             p.ValueSelectionStarted -= OnSelectStarted;
             p.ValueSelectionEnded -= OnSelectEnded;
-
-            p.RerollDrawn -= OnRerollDraw;
-            p.RerollDiscarded -= OnRerollDiscard;
-            p.RerollEnded -= OnRerollEnd;
+            
             p.Drawn -= OnDraw;
             p.Discarded -= OnDiscard;
         }
@@ -271,7 +265,7 @@ namespace Cardevil.Cards.InStage.View
 
         #region Draw/Discard Event
 
-        private void OnRerollDraw()
+        public void AnimateRerollDraw()
         {
             _deckVisual.OnInteraction();
             transform.DOMove(endValue: parentCard.transform.position, visualSetting.RerollDrawDuration)
@@ -284,12 +278,12 @@ namespace Cardevil.Cards.InStage.View
                         .SetEase(visualSetting.FlipEase));
         }
 
-        private void OnRerollDiscard(Transform discardPoint)
+        public void AnimateRerollDiscard()
         {
             _state.isDiscarded = true;
             RemoveAllEvents();
 
-            var tween = transform.DOMove(endValue: discardPoint.position, visualSetting.RerollDiscardDuration)
+            var tween = transform.DOMove(endValue: _deckVisual.Front.position, visualSetting.RerollDiscardDuration)
                         .SetEase(visualSetting.RerollDiscardEase);
 
             var sequence = DOTween.Sequence();
@@ -305,7 +299,7 @@ namespace Cardevil.Cards.InStage.View
             });
         }
 
-        private void OnRerollEnd()
+        public void EndReroll()
         {
             _canvas.overrideSorting = false;
         }


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 REFACTOR: 카드 이벤트 구조 개선 및 구독 책임 정리

## 📑 개요
<!--
   목적, 변경사항, 사용법에 대한 간략한 설명
   스크린샷이 포함될 수 있습니다.
-->

`StageCardsPresenter`–`Card`–`CardVisual` 간 이벤트 책임을 명확히 하고,
불필요한 이벤트를 제거하여 구조를 단순화했습니다.

---

## ✏️ 변경(추가) 사항

### 1) Presenter -> Card 구조 내 이벤트 연결/해제 책임 명확화
•	Presenter가 카드 생성/제거 시점에 이벤트를 구독/해제하도록 수정

### 2) Card <-> CardVisual 간 구독 책임 분리
•	Card가 Visual을 생성하므로, 구독/해제 책임을 Card가 맡도록 변경

### 3) 이벤트 접근 제한
•	private event + Add/Remove 메서드 패턴으로 외부 접근 통제

### 4) 불필요한 이벤트 제거
•	단순 호출로 충분한 Card–CardVisual 간 일부 이벤트를 직접 메서드 호출로 대체

---

## ✅ 체크리스트
<!--
  해당 PR을 올리기 전에, 반드시 체크해야할 리스트입니다.
  [ ] : 체크안됨
  [x] : 체크됨
-->
- [x] Namespace 규칙 확인
- [x] public 함수의 경우 주석 확인

---

## 연관 PR
<!--
  (Optional)
  없는 경우 제거
-->
#61 

---



