### PR TITLE
fix: 랜덤 유틸 편향 수정

### DIFF
--- a/Assets/Scripts/Utils/RandomUtil.cs
+++ b/Assets/Scripts/Utils/RandomUtil.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using Cardevil.DebugConsole;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using UMRandom = Unity.Mathematics.Random;
 using URandom = UnityEngine.Random;
 
@@ -65,6 +67,10 @@ namespace Cardevil.Utils
                 int j = randoms[type].NextInt(0, i + 1);
                 (list[i], list[j]) = (list[j], list[i]);
             }
+            
+            // 테스트용으로 시드 삭제
+            randoms.Remove(type);
+            randomSeeds.Remove(type);
         }
 
         [Serializable]
@@ -102,6 +108,37 @@ namespace Cardevil.Utils
                 InitSeed(save.type, save.initialSeed, save.state);
             }
             _isInitialized = true;
+        }
+    }
+    
+    public class RandomUtilShuffleTest
+    {
+        /*
+         * 카드 셔플을 하면 많은 경우
+         * Red 2, 3, 4, 5가 포함되어 있다고 느껴졌음.
+         * 검증을 위해 ShuffleTest 클래스를 만듦.
+         */
+        
+        [ConsoleCommand("testShuffle")]
+        public static void Test()
+        {
+            int deckSize = 50, handSize = 6, trialCount = 500_000;
+            int[] buckets = new int[5]; // id 0~3 중, 0~4장 포함 카운트
+            
+            for (int t = 0; t < trialCount; t++)
+            {
+                var deck = Enumerable.Range(0, deckSize).ToList();
+                deck.ShuffleListInPlace(); // 테스트 위해 셔플마다 시드 삭제 후 InitSeed()
+
+                int cnt = deck.Take(handSize).Count(id => id < 4);
+                buckets[cnt]++;
+            }
+
+            for (int k = 0; k <= 4; k++)
+                LogEx.Log($"{k}장 포함: {(double)buckets[k]/trialCount*100:F3}%");
+
+            double rate = (double)buckets[4]/trialCount*100;
+            LogEx.Log($"모두 포함 확률: {rate:F5}%");
         }
     }
 }

--- a/Assets/Scripts/Utils/RandomUtil.cs
+++ b/Assets/Scripts/Utils/RandomUtil.cs
@@ -48,7 +48,12 @@ namespace Cardevil.Utils
             {
                 InitSeed(type);
             }
-            return randoms[type].NextInt(min, max);
+
+            var random = randoms[type];
+            int result = random.NextInt(min, max);
+            randoms[type] = random; // UMRandom이 struct이기 때문.
+            
+            return result;
         }
         
         /// <summary>
@@ -57,14 +62,10 @@ namespace Cardevil.Utils
         public static void ShuffleListInPlace<T>(this IList<T> list, RandomType type = RandomType.CardShuffle)
         {
             if (list == null) throw new ArgumentNullException(nameof(list));
-            
-            // Random Type의 초기화가 안 되어 있다면 초기화
-            if (!randoms.TryGetValue(type, out var r))
-                InitSeed(type);
 
             for (int i = list.Count - 1; i > 0; i--)
             {
-                int j = randoms[type].NextInt(0, i + 1);
+                int j = GetRandomInt(0, i + 1, type);
                 (list[i], list[j]) = (list[j], list[i]);
             }
             


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 FIX: 랜덤 유틸 편향 수정

## 📑 개요
<!--
   목적, 변경사항, 사용법에 대한 간략한 설명
   스크린샷이 포함될 수 있습니다.
-->
<img width="371" height="144" alt="스크린샷 2025-10-28 오후 9 01 20" src="https://github.com/user-attachments/assets/49ba9714-1678-45cd-8f87-69bab636f6b7" />

RandomUtil의 랜덤 결과가 편향되어 나타나던 문제를 수정했습니다.

---

## ✏️ 변경(추가) 사항

### 1) GetNextInt()
Unity.Mathematics.Random(UMRandom)이 struct 타입이기 때문에,
NextInt() 호출 시 값 복사가 발생하여 내부 상태가 갱신되지 않는 문제가 있었습니다.

이를 해결하기 위해, NextInt() 호출 후 수정된 인스턴스를 다시 딕셔너리에 등록하도록 변경했습니다.

```C#
var random = randoms[type];
int result = random.NextInt(min, max);
randoms[type] = random; // UMRandom이 struct이기 때문.

return result;
```

---

## 연관 이슈
<!--
  (Optional)
  없는 경우 제거
-->
#65 

