### PR TITLE
FIX : 랜덤유틸이 초기 시드를 저장하지 않던 문제 수정

### DIFF
--- a/Assets/Scripts/Utils/RandomUtil.cs
+++ b/Assets/Scripts/Utils/RandomUtil.cs
@@ -18,7 +18,7 @@ namespace Cardevil.Utils
         }
         
         private static Dictionary<RandomType, UMRandom> randoms = new Dictionary<RandomType, UMRandom>();
-        private static Dictionary<RandomType, uint> randomSeeds = new Dictionary<RandomType, uint>();
+        private static Dictionary<RandomType, uint> randomInitialSeeds = new Dictionary<RandomType, uint>();
         
         
         private static bool _isInitialized = false;
@@ -36,10 +36,14 @@ namespace Cardevil.Utils
         {
             if (setSeed == 0)
             {
-                setSeed = initialSeed == 0 ? (uint) URandom.Range(int.MinValue, int.MaxValue) : initialSeed;
+                if (initialSeed == 0)
+                {
+                    initialSeed = (uint)URandom.Range(1, int.MaxValue);
+                }
+                setSeed = initialSeed;
             }
             randoms[type] = new UMRandom(setSeed);
-            randomSeeds[type] = setSeed;
+            randomInitialSeeds[type] = initialSeed;
         }
         
         public static int GetRandomInt(int min, int max, RandomType type = RandomType.Default)
@@ -113,7 +117,7 @@ namespace Cardevil.Utils
                 saves.Add(new RandomSave
                 {
                     type = kvp.Key,
-                    initialSeed = randomSeeds[kvp.Key],
+                    initialSeed = randomInitialSeeds[kvp.Key],
                     state = kvp.Value.state
                 });
             }


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 FIX : 랜덤유틸이 초기 시드를 저장하지 않던 문제 수정
## 📑 개요
<!--
   목적, 변경사항, 사용법에 대한 간략한 설명
   스크린샷이 포함될 수 있습니다.
-->
---

기존 랜덤 유틸이 초기시드를 저장하지 않던 문제를 수정했습니다.
