### PR TITLE
feat: 평가 텍스트 애니메이션 개선

### DIFF
--- a/Assets/Resources/Prefabs/Cards/CardVisual.prefab
+++ b/Assets/Resources/Prefabs/Cards/CardVisual.prefab
@@ -204,7 +204,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   parentCard: {fileID: 0}
   visualSetting: {fileID: 11400000, guid: 4b7539de82d4b4b63b8d9ff49ee71fed, type: 2}
-  spriteFactory: {fileID: 11400000, guid: 9b3a98705a1a145759601d30ac022742, type: 2}
+  animSo: {fileID: 11400000, guid: 86cca5790825e4f938459e939ac90ea1, type: 2}
   shakeObject: {fileID: 8032909874445604869}
   frontImage: {fileID: 850331243366006085}
   backImage: {fileID: 2095012618064697300}

--- a/Assets/Scripts/Cards/Evaluations/EvaluationPresenter.cs
+++ b/Assets/Scripts/Cards/Evaluations/EvaluationPresenter.cs
@@ -122,8 +122,7 @@ namespace Cardevil.Cards.Evaluations
                     step.CalculateDamage(ref totalDamage);
                     _view.RegisterStep(step);
                     
-                    if (i != stepGroup.Count - 1)
-                        await UniTask.Delay(TimeSpan.FromSeconds(.3f));
+                    await UniTask.Delay(TimeSpan.FromSeconds(.3f));
                 }
                 
                 await _view.DoStep(totalDamage);

--- a/Assets/Scripts/Cards/Evaluations/EvaluationPresenter.cs
+++ b/Assets/Scripts/Cards/Evaluations/EvaluationPresenter.cs
@@ -120,6 +120,7 @@ namespace Cardevil.Cards.Evaluations
                 {
                     var step = stepGroup[i];
                     step.CalculateDamage(ref totalDamage);
+                    step.ExecuteVisualEffect();
                     _view.RegisterStep(step);
                     
                     await UniTask.Delay(TimeSpan.FromSeconds(.3f));

--- a/Assets/Scripts/Cards/Evaluations/EvaluationSequenceFactory.cs
+++ b/Assets/Scripts/Cards/Evaluations/EvaluationSequenceFactory.cs
@@ -31,9 +31,13 @@ namespace Cardevil.Cards.Evaluations
             // Move Only
             if (attackCards.Count == 0 && moveCards.Count > 0)
             {
+                List<IEvaluateVisual> visuals = new();
+                foreach (var card in moveCards)
+                    visuals.Add(card.EvaluateVisual);
+                
                 seq.Append(EvaluationStep.Get()
                     .SetValue(EvaluationStep.Type.Move)
-                    .SetVisual(moveCards));
+                    .SetVisual(visuals));
 
                 return seq;
             }
@@ -67,9 +71,13 @@ namespace Cardevil.Cards.Evaluations
             // 기본 족보 보너스
             if (data != null && handRanking > HandRanking.High)
             {
+                List<IEvaluateVisual> visuals = new();
+                foreach (var card in inRankCards)
+                    visuals.Add(card.EvaluateVisual);
+                
                 seq.Append(EvaluationStep.Get()
                     .SetValue(EvaluationStep.Type.Plus, data.Value)
-                    .SetVisual(inRankCards)); // 족보에 포함되는 카드들만 추가함
+                    .SetVisual(visuals)); // 족보에 포함되는 카드들만 추가함
             }
             
             // 기본 데미지 + 보너스 데미지
@@ -85,7 +93,7 @@ namespace Cardevil.Cards.Evaluations
                 
                 seq.Append(EvaluationStep.Get()
                     .SetValue(EvaluationStep.Type.Plus, topVal)
-                    .SetVisual(top));
+                    .SetVisual(top.EvaluateVisual));
                 
                 // 추가 데미지 유물 효과 적용
                 foreach (var effect in perCardBonus)
@@ -99,7 +107,7 @@ namespace Cardevil.Cards.Evaluations
                     
                     seq.Append(EvaluationStep.Get()
                         .SetValue(EvaluationStep.Type.Plus, v)
-                        .SetVisual(card));
+                        .SetVisual(card.EvaluateVisual));
                     
                     // 추가 데미지 유물 효과 적용
                     foreach (var effect in perCardBonus)

--- a/Assets/Scripts/Cards/Evaluations/EvaluationSequenceFactory.cs
+++ b/Assets/Scripts/Cards/Evaluations/EvaluationSequenceFactory.cs
@@ -1,7 +1,7 @@
 using Cardevil.Cards.Data;
-using Cardevil.Cards.Data.InStage;
 using Cardevil.Cards.InStage.Model.ReadOnly;
 using Cardevil.Cards.InStage.Presenter;
+using Cardevil.Relics.OnEvaluation;
 using System.Collections.Generic;
 using System.Linq;
 using Cardevil.Utils;
@@ -11,77 +11,114 @@ namespace Cardevil.Cards.Evaluations
     public class EvaluationSequenceFactory
     {
         private readonly IReadOnlyEvaluationResultsModel _model;
-        
+
         public EvaluationSequenceFactory(IReadOnlyEvaluationResultsModel model)
         {
             _model = model;
         }
-        
+
         public EvaluationSequence ConfigureSequence(IEnumerable<Card> selection)
         {
             EvaluationSequence seq = EvaluationSequence.Get();
-            
-            List<Card> attackCards = selection.Where(c => c.Data.Kind == CardKind.Attack).ToList();
-            List<Card> moveCards = selection.Where(c => c.Data.Kind == CardKind.Move).ToList();
-            
+            if (selection == null) return seq;
+
+            // 분류
+            var attackCards = new List<Card>();
+            var moveCards = new List<Card>();
+            foreach (var c in selection)
+                (c.Data.Kind == CardKind.Attack ? attackCards : moveCards).Add(c);
+
             // Move Only
             if (attackCards.Count == 0 && moveCards.Count > 0)
             {
-                seq.Append(
-                    EvaluationStep.Get()
+                seq.Append(EvaluationStep.Get()
                     .SetValue(EvaluationStep.Type.Move)
                     .SetVisual(moveCards));
 
                 return seq;
             }
+
+            // 유물 버킷
+            var perCardBonus = new List<IRelicEffectOnEvaluation>(2);
+            var plusEffects = new List<IRelicEffectOnEvaluation>();
+            var mulEffects = new List<IRelicEffectOnEvaluation>();
+
             
-            // 족보 계산
-            HandRanking handRanking = HandRankingEvaluator.EvaluateHandRanking(attackCards, out var cardsInHandRanking);
+            foreach (var owned in Managers.Relic.OwnedRelics)
+            foreach (var eff in owned.Relic.Effects)
+            {
+                if (eff is not IRelicEffectOnEvaluation onEval)
+                    continue;
+                switch (onEval)
+                {
+                    case DamageOnEachCardEffect perCard: perCardBonus.Add(perCard); break;
+                    default: (onEval.IsPlus ? plusEffects : mulEffects).Add(onEval); break;
+                }
+            }
+            
+            // 족보
+            var handRanking = HandRankingEvaluator.EvaluateHandRanking(attackCards, out var inRankCards);
+            // TODO: db 접근 처음에 일괄적으로 하도록 바꾸기
+            var data = Managers.Database.Database.HandRankingDataList
+                .FirstOrDefault(d => d.Ranking == handRanking);
+            if (data == null)
+                LogEx.LogWarning($"Database에 족보 데이터가 존재하지 않음! : {handRanking}");
             
             // 기본 족보 보너스
-            if (handRanking > HandRanking.High)
+            if (data != null && handRanking > HandRanking.High)
             {
-                // TODO: db 접근 처음에 일괄적으로 하도록 바꾸기
-                var data = Managers.Database.Database.HandRankingDataList
-                    .FirstOrDefault(d => d.Ranking == handRanking);
-
-                if (data == null)
-                {
-                    LogEx.LogError($"Database에 족보 데이터가 존재하지 않음! : {handRanking}");
-                    return seq;
-                }
-
                 seq.Append(EvaluationStep.Get()
                     .SetValue(EvaluationStep.Type.Plus, data.Value)
-                    .SetVisual(cardsInHandRanking)); // 족보에 포함되는 카드들만 추가함
+                    .SetVisual(inRankCards)); // 족보에 포함되는 카드들만 추가함
             }
             
-            // TODO: 기본 데미지 유물
-
-            // 기본 데미지
+            // 기본 데미지 + 보너스 데미지
             if (handRanking == HandRanking.High)
             {
-                var top = attackCards.Aggregate((best, cur) =>
-                    cur.Data.NumberSelectState.FinalValue > best.Data.NumberSelectState.FinalValue ? cur : best);
-                seq.Append(EvaluationStep.Get()
-                    .SetValue(EvaluationStep.Type.Plus, (float)top.Data.NumberSelectState.FinalValue)
-                    .SetVisual(top));
-                // 추가 데미지
-            }
-            else if (handRanking != HandRanking.None)
-            {
-                foreach (var card in cardsInHandRanking)
+                Card top = attackCards[0];
+                float topVal = (int)top.Data.NumberSelectState.FinalValue;
+                for (int i = 1; i < attackCards.Count; i++)
                 {
+                    int v = (int)attackCards[i].Data.NumberSelectState.FinalValue;
+                    if (v > topVal) { top = attackCards[i]; topVal = v; }
+                }
+                
+                seq.Append(EvaluationStep.Get()
+                    .SetValue(EvaluationStep.Type.Plus, topVal)
+                    .SetVisual(top));
+                
+                // 추가 데미지 유물 효과 적용
+                foreach (var effect in perCardBonus)
+                    seq.Join(effect.MakeEvaluationStep());
+            }
+            else if (handRanking != HandRanking.None && inRankCards?.Count > 0)
+            {
+                foreach (var card in inRankCards)
+                {
+                    float v = (int)card.Data.NumberSelectState.FinalValue;
+                    
                     seq.Append(EvaluationStep.Get()
-                        .SetValue(EvaluationStep.Type.Plus, (float)card.Data.NumberSelectState.FinalValue)
+                        .SetValue(EvaluationStep.Type.Plus, v)
                         .SetVisual(card));
-                    // 추가 데미지
+                    
+                    // 추가 데미지 유물 효과 적용
+                    foreach (var effect in perCardBonus)
+                        seq.Join(effect.MakeEvaluationStep());
                 }    
             }
-            
-            // TODO: Plus 유물
-            
-            // TODO: Multiply 유물
+
+            // 유물 효과 적용
+            foreach (var effect in plusEffects)
+            {
+                if (effect.CanTrigger(handRanking, _model))
+                    seq.Append(effect.MakeEvaluationStep());
+            }
+
+            foreach (var effect in mulEffects)
+            {
+                if (effect.CanTrigger(handRanking, _model))
+                    seq.Append(effect.MakeEvaluationStep());
+            }
 
             return seq;
         }

--- a/Assets/Scripts/Cards/Evaluations/EvaluationStep.cs
+++ b/Assets/Scripts/Cards/Evaluations/EvaluationStep.cs
@@ -87,6 +87,12 @@ namespace Cardevil.Cards.Evaluations
             Plus, Multiply
         }
 
+        public void ExecuteVisualEffect()
+        {
+            foreach (var visual in _visuals)
+                visual.ExecuteEvaluationAction();
+        }
+
         // public float Evaluate(float damage, out EvaluationEffect effect, out float value)
         // {
         //     switch (_effectType)

--- a/Assets/Scripts/Cards/Evaluations/EvaluationView.cs
+++ b/Assets/Scripts/Cards/Evaluations/EvaluationView.cs
@@ -11,6 +11,11 @@ using NotImplementedException = System.NotImplementedException;
 
 namespace Cardevil.Cards.Evaluations
 {
+    /*
+     * 1. sub 글자가 사라지기 (ok)
+     * 2. value에 따라 main 텍스트 올라가는 시간이 바뀌기
+     * 3. 점점 빨라지기
+     */
     public class EvaluationView : MonoBehaviour, IClearable
     {
         [SerializeField] private CardEvaluationAnimSO animSO;

--- a/Assets/Scripts/Cards/Evaluations/EvaluationView.cs
+++ b/Assets/Scripts/Cards/Evaluations/EvaluationView.cs
@@ -78,13 +78,13 @@ namespace Cardevil.Cards.Evaluations
             _mainRankingTween?.Kill();
             _subRankingTween?.Kill();
             main.localScale = Vector3.one;
-            subRect.anchoredPosition = new Vector3(animSO.s_posX, 0);
+            subRect.anchoredPosition = new Vector3(animSO.subPosX, 0);
 
             // 새 Tween
-            _mainRankingTween = main.DOScale(1.2f, animSO.m_RankingChangeDur)
+            _mainRankingTween = main.DOScale(animSO.mainRankingScaleValue, animSO.mainRankingChangeDur)
                 .SetLoops(2, LoopType.Yoyo)
                 .SetAutoKill(true).SetLink(main.gameObject);
-            _subRankingTween = subRect.DOAnchorPosX(0, animSO.s_RankingChangeDur)
+            _subRankingTween = subRect.DOAnchorPosX(0, animSO.subRankingChangeDur)
                 .SetAutoKill(true).SetLink(sub.gameObject);
 
             _mainText.UpdateText(data.DisplayName);
@@ -105,12 +105,12 @@ namespace Cardevil.Cards.Evaluations
             _stepSeq?.Kill();
             _stepSeq = DOTween.Sequence().SetAutoKill(true).SetLink(sub.gameObject);
             
-            rect.anchoredPosition= new Vector3(animSO.s_posX * 1.5f, _lastStepY);
+            rect.anchoredPosition= new Vector3(animSO.subPosX * 1.5f, _lastStepY);
             string oper = s.StepType == EvaluationStep.Type.Plus ? "+" : "x"; // TODO: 더 제대로 나눠야함.
             sub.UpdateText($"{oper}{s.Value}");
             
             _stepSeq
-                .Append(rect.DOAnchorPosX(animSO.s_posX, animSO.s_evaDur).SetEase(animSO.s_evaEase));
+                .Append(rect.DOAnchorPosX(animSO.subPosX, animSO.subEvaDur).SetEase(animSO.subEvaEase));
             
             RegisteredSubs.Enqueue(sub);
             _lastStepY += 100f;
@@ -137,7 +137,14 @@ namespace Cardevil.Cards.Evaluations
                 var rect = sub.transform.parent.GetComponent<RectTransform>();
 
                 var seq = DOTween.Sequence()
-                    .Append(rect.DOAnchorPosX(0, animSO.s_evaDur).SetEase(animSO.s_evaEase))
+                    .Append(rect.DOAnchorPosX(0, animSO.subEvaDur)
+                        .SetEase(animSO.subEvaEase))
+                    .Join(DOTween.To(
+                        () => 1f,
+                        sub.SetAlpha,
+                        0f,
+                        animSO.subEvaDur)
+                        .SetEase(animSO.subFadeOutEase))
                     .SetAutoKill()
                     .SetRecyclable()
                     .SetLink(gameObject);
@@ -148,12 +155,13 @@ namespace Cardevil.Cards.Evaluations
             await UniTask.WhenAll(waitAll);
             
             var mainSeq = DOTween.Sequence()
-                .Append(main.DOScale(1.1f, animSO.m_evaDur))
+                .Append(main.DOScale(animSO.mainRankingScaleValue, animSO.mainEvaDur)
+                    .SetLoops(2, LoopType.Yoyo))
                 .Join(DOTween.To(
                     () => _prevDamage,
                     v => _mainText.UpdateText(v.ToString("0")),
                     totalDamage,
-                    animSO.m_evaChangeDur))
+                    animSO.mainEvaChangeDur))
                 .SetAutoKill()
                 .SetRecyclable()
                 .SetLink(gameObject);
@@ -188,6 +196,7 @@ namespace Cardevil.Cards.Evaluations
 
         private async UniTask ClearText(TextAnimator text)
         {
+            return;
             var seq = DOTween.Sequence()
                 .Append(DOTween.To(
                     () => 1f,

--- a/Assets/Scripts/Cards/Evaluations/EvaluationView.cs
+++ b/Assets/Scripts/Cards/Evaluations/EvaluationView.cs
@@ -48,9 +48,9 @@ namespace Cardevil.Cards.Evaluations
         
         public void Clear()
         {
-            _mainText.ClearText();
+            ClearTextAsync(_mainText).Forget();
             foreach (var sub in SubPool)
-                sub.ClearText();
+                ClearTextAsync(sub).Forget();
             _prevDamage = 0f;
         }
         
@@ -60,12 +60,10 @@ namespace Cardevil.Cards.Evaluations
             _lastRanking = ranking;
 
             var sub = GetSub();
-            var subRect= sub.transform.parent.GetComponent<RectTransform>();
-
-            if (ranking is HandRanking.None or HandRanking.High)
+            if (ranking is HandRanking.None)
             {
-                ClearText(_mainText);
-                ClearText(sub);
+                ClearTextAsync(_mainText).Forget();
+                ClearTextAsync(sub).Forget();
                 SubPool.Enqueue(sub);
                 return;
             }
@@ -74,6 +72,8 @@ namespace Cardevil.Cards.Evaluations
                 .FirstOrDefault(i => i.Ranking == ranking);
             if (data == null) { LogEx.LogError($"Can't find HandRanking Data: {ranking}"); return; }
 
+            var subRect= sub.transform.parent.GetComponent<RectTransform>();
+            
             // 이전 Tween 정리 및 Transform 초기화
             _mainRankingTween?.Kill();
             _subRankingTween?.Kill();
@@ -172,7 +172,7 @@ namespace Cardevil.Cards.Evaluations
             // 3. 다시 pool에 sub Text 반환
             foreach (var sub in subs)
             {
-                await ClearText(sub);
+                sub.ClearText();
                 SubPool.Enqueue(sub);
             }
         }
@@ -194,18 +194,15 @@ namespace Cardevil.Cards.Evaluations
             return sub;
         }
 
-        private async UniTask ClearText(TextAnimator text)
+        private async UniTaskVoid ClearTextAsync(TextAnimator text)
         {
-            return;
-            var seq = DOTween.Sequence()
+            await DOTween.Sequence()
                 .Append(DOTween.To(
                     () => 1f,
                     text.SetAlpha,
                     0f,
-                    .1f))
-                .OnComplete(text.ClearText);
-            
-            await seq;
+                    animSO.clearTextDur));
+            text.ClearText();
         }
     }
 }

--- a/Assets/Scripts/Cards/Evaluations/EvaluationView.cs
+++ b/Assets/Scripts/Cards/Evaluations/EvaluationView.cs
@@ -13,7 +13,7 @@ namespace Cardevil.Cards.Evaluations
 {
     /*
      * 1. sub 글자가 사라지기 (ok)
-     * 2. value에 따라 main 텍스트 올라가는 시간이 바뀌기
+     * 2. value에 따라 main 텍스트 올라가는 시간이 바뀌기 (ok)
      * 3. 점점 빨라지기
      */
     public class EvaluationView : MonoBehaviour, IClearable
@@ -123,19 +123,17 @@ namespace Cardevil.Cards.Evaluations
         {
             if (RegisteredSubs.Count == 0)
                 return;
-            
             _mainText.UpdateText(_prevDamage.ToString());
 
+            // 1. sub Text 이동
             var subs = new List<TextAnimator>(RegisteredSubs.Count);
             while(RegisteredSubs.Count > 0)
                 subs.Add(RegisteredSubs.Dequeue());
-
+            
             var waitAll = new List<UniTask>(subs.Count);
-
             foreach (var sub in subs)
             {
                 var rect = sub.transform.parent.GetComponent<RectTransform>();
-
                 var seq = DOTween.Sequence()
                     .Append(rect.DOAnchorPosX(0, animSO.subEvaDur)
                         .SetEase(animSO.subEvaEase))
@@ -151,9 +149,10 @@ namespace Cardevil.Cards.Evaluations
 
                 waitAll.Add(seq.AwaitForComplete());
             }
-            
             await UniTask.WhenAll(waitAll);
             
+            // 2. main Text에 total damage 반영
+            float dur = ((totalDamage - _prevDamage) / 10f + 1) * animSO.mainEvaChangeDur; // 데미지에 따라 시간 늘어나도록
             var mainSeq = DOTween.Sequence()
                 .Append(main.DOScale(animSO.mainRankingScaleValue, animSO.mainEvaDur)
                     .SetLoops(2, LoopType.Yoyo))
@@ -161,7 +160,7 @@ namespace Cardevil.Cards.Evaluations
                     () => _prevDamage,
                     v => _mainText.UpdateText(v.ToString("0")),
                     totalDamage,
-                    animSO.mainEvaChangeDur))
+                    dur))
                 .SetAutoKill()
                 .SetRecyclable()
                 .SetLink(gameObject);
@@ -170,6 +169,7 @@ namespace Cardevil.Cards.Evaluations
             _prevDamage = totalDamage;
             _lastStepY = 0f;
 
+            // 3. 다시 pool에 sub Text 반환
             foreach (var sub in subs)
             {
                 await ClearText(sub);

--- a/Assets/Scripts/Cards/Evaluations/HandRankingEvaluator.cs
+++ b/Assets/Scripts/Cards/Evaluations/HandRankingEvaluator.cs
@@ -102,12 +102,18 @@ namespace Cardevil.Cards.Evaluations
             if (numberCards.Count != 4) 
                 return false;
             
-            bool value = numberCards.Select(c => c.Data.NumberSelectState.FinalValue)
-                    .Distinct()
-                    .Count() == 1;
-            
-            if (value) cardsInRanking = numberCards.ToList();
-            return value;
+            bool allSameColor = true;
+            for (int i = 1; i < numberCards.Count; i++)
+            {
+                if (numberCards[i].Data.Color == numberCards[i - 1].Data.Color)
+                    continue;
+
+                allSameColor = false;
+                break;
+            }
+
+            if (allSameColor) cardsInRanking = numberCards;
+            return allSameColor;
         }
 
         private static bool IsStraightFlush(List<Card> numberCards,  out List<Card> cardsInRanking)

--- a/Assets/Scripts/Cards/Evaluations/IEvaluateVisual.cs
+++ b/Assets/Scripts/Cards/Evaluations/IEvaluateVisual.cs
@@ -8,6 +8,6 @@ namespace Cardevil.Cards.Evaluations
         /// <summary>
         /// Evaluation 시 반응.
         /// </summary>
-        public void ExecuteEvaluationAction();
+        void ExecuteEvaluationAction();
     }
 }

--- a/Assets/Scripts/Cards/Evaluations/TextAnimator.cs
+++ b/Assets/Scripts/Cards/Evaluations/TextAnimator.cs
@@ -1,3 +1,4 @@
+using Cardevil.Utils;
 using Cysharp.Threading.Tasks;
 using System.Threading;
 using TMPro;
@@ -35,11 +36,12 @@ namespace Cardevil.Cards.Evaluations
             _defaultColor = _textComponent.color;
             
             RestartAnimation();
-            UpdateText("");
+            ClearText();
         }
 
         public void ClearText()
         {
+            LogEx.Log($"{name} {Time.time}");
             UpdateText(string.Empty);
         }
 
@@ -61,7 +63,7 @@ namespace Cardevil.Cards.Evaluations
         }
 
         /// <summary>
-        /// AnchoredPositin을 설정합니다.
+        /// AnchoredPosition을 설정합니다.
         /// </summary>
         public void SetPosition(Vector3 position)
         {
@@ -77,8 +79,7 @@ namespace Cardevil.Cards.Evaluations
             alpha = Mathf.Clamp01(alpha);
             _textComponent.color = new Color(c.r, c.g, c.b, alpha);
         }
-
-
+        
         private void RestartAnimation()
         {
             _cts?.Cancel();
@@ -86,7 +87,7 @@ namespace Cardevil.Cards.Evaluations
             PlayShakeAnimationAsync(_cts.Token).Forget();
         }
 
-        private async UniTask PlayShakeAnimationAsync(CancellationToken token)
+        private async UniTaskVoid PlayShakeAnimationAsync(CancellationToken token)
         {
             _textComponent.ForceMeshUpdate();
             var textInfo = _textComponent.textInfo;

--- a/Assets/Scripts/Cards/Evaluations/TextAnimator.cs
+++ b/Assets/Scripts/Cards/Evaluations/TextAnimator.cs
@@ -75,7 +75,7 @@ namespace Cardevil.Cards.Evaluations
         {
             var c = _defaultColor;
             alpha = Mathf.Clamp01(alpha);
-            _textComponent.faceColor = new Color(c.r, c.g, c.b, alpha);
+            _textComponent.color = new Color(c.r, c.g, c.b, alpha);
         }
 
 

--- a/Assets/Scripts/Cards/Evaluations/TextAnimator.cs
+++ b/Assets/Scripts/Cards/Evaluations/TextAnimator.cs
@@ -41,7 +41,6 @@ namespace Cardevil.Cards.Evaluations
 
         public void ClearText()
         {
-            LogEx.Log($"{name} {Time.time}");
             UpdateText(string.Empty);
         }
 

--- a/Assets/Scripts/Cards/InStage/Presenter/Card.cs
+++ b/Assets/Scripts/Cards/InStage/Presenter/Card.cs
@@ -16,7 +16,7 @@ using UnityEngine.UIElements;
 namespace Cardevil.Cards.InStage.Presenter
 {
     [RequireComponent(typeof(Poolable))]
-    public class Card : MonoBehaviour, IEvaluateVisual, IClearable,
+    public class Card : MonoBehaviour, IClearable,
                         IDragHandler, IBeginDragHandler, IEndDragHandler, 
                         IPointerEnterHandler, IPointerExitHandler, IPointerUpHandler, IPointerDownHandler
     {
@@ -34,8 +34,7 @@ namespace Cardevil.Cards.InStage.Presenter
         private Poolable _poolable;
         private IReadOnlyStageCardsModel _model;
 
-        #region Property
-
+        public IEvaluateVisual EvaluateVisual => visual;
         public CardData Data => data;
         public bool IsDragging => state.isDragging;
         public bool IsReroll => state.isReroll;
@@ -50,38 +49,6 @@ namespace Cardevil.Cards.InStage.Presenter
                 return true;
             }
         }
-
-        #endregion
-        
-        #region Unity Event
-
-        private void Awake()
-        {
-            Clear();
-            _poolable = GetComponent<Poolable>();
-            _poolable.OnRelease += Clear;
-        }
-        
-        private void Update()
-        {
-            if (state.isDiscarded) return;
-
-            if (state.isDragging)
-            {
-                // var targetPosition = Input.mousePosition - pointerOffset;
-                var targetPosition = Input.mousePosition;
-                var direction = (targetPosition - transform.position).normalized;
-
-                var neededVelocity = Vector2.Distance(transform.position, targetPosition) / Time.deltaTime;
-                var velocity = direction * Mathf.Min(visualSetting.MoveSpeedLimit, neededVelocity);
-
-                transform.Translate(velocity * Time.deltaTime);
-            }
-        }
-
-        #endregion
-
-        #region Initialization
 
         /// <summary>
         /// 카드 데이터 및 비주얼 초기화.
@@ -110,6 +77,32 @@ namespace Cardevil.Cards.InStage.Presenter
         {
             state = new CardState();
             visual = null;
+        }
+        
+        #region Unity Event
+
+        private void Awake()
+        {
+            Clear();
+            _poolable = GetComponent<Poolable>();
+            _poolable.OnRelease += Clear;
+        }
+        
+        private void Update()
+        {
+            if (state.isDiscarded) return;
+
+            if (state.isDragging)
+            {
+                // var targetPosition = Input.mousePosition - pointerOffset;
+                var targetPosition = Input.mousePosition;
+                var direction = (targetPosition - transform.position).normalized;
+
+                var neededVelocity = Vector2.Distance(transform.position, targetPosition) / Time.deltaTime;
+                var velocity = direction * Mathf.Min(visualSetting.MoveSpeedLimit, neededVelocity);
+
+                transform.Translate(velocity * Time.deltaTime);
+            }
         }
 
         #endregion

--- a/Assets/Scripts/Cards/InStage/View/CardVisual.cs
+++ b/Assets/Scripts/Cards/InStage/View/CardVisual.cs
@@ -22,6 +22,7 @@ namespace Cardevil.Cards.InStage.View
         
         [Header("SO")]
         [SerializeField] private CardVisualSettingSO visualSetting;
+        [SerializeField] private CardEvaluationAnimSO animSo;
 
         [Header("Card Visual")]
         [SerializeField] private Transform shakeObject;
@@ -318,7 +319,10 @@ namespace Cardevil.Cards.InStage.View
         
         public void ExecuteEvaluationAction()
         {
-            transform.DOShakePosition(.6f, 50);
+            var seq = DOTween.Sequence()
+                .Append(transform.DOScale(animSo.cardScaleValue, animSo.cardScaleDur)
+                    .SetEase(animSo.cardScaleEase)
+                    .SetLoops(2, LoopType.Yoyo));
         }
 
         #region nested

--- a/Assets/Scripts/Cards/ScriptableObjects/CardEvaluationAnimSO.cs
+++ b/Assets/Scripts/Cards/ScriptableObjects/CardEvaluationAnimSO.cs
@@ -1,6 +1,7 @@
 using Cardevil.Attributes;
 using DG.Tweening;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Cardevil.Cards.ScriptableObjects
 {
@@ -8,29 +9,50 @@ namespace Cardevil.Cards.ScriptableObjects
     public class CardEvaluationAnimSO : ScriptableObject
     {
         [VisibleOnly, SerializeField, TextArea]
-        string description = "족보 선택/카드 변경 글자 애니메이션 설정 SO입니다.";
+        private string description = "족보 선택/카드 변경 글자 애니메이션 설정 SO입니다.";
 
         [Header("Common")]
+        [FormerlySerializedAs("s_posX")]
         [Tooltip("Sub PosX")]
-        [Min(30f)] public float s_posX;
+        [Min(30f)] public float subPosX;
+        
+        [Tooltip("Main Scale Tween의 value. 이만큼 확대"), Min(1f)]
+        public float mainRankingScaleValue;
 
+        
         [Header("Ranking Changed")]
+        [FormerlySerializedAs("m_RankingChangeDur"), Min(0f)]
         [Tooltip("Main Scale Tween 지속 시간. 이 시간만큼 두 번 반복.")]
-        [Min(0f)] public float m_RankingChangeDur;
+        public float mainRankingChangeDur;
 
-        [Tooltip("Sub PosX Tween 지속 시간.")]
-        [Min(0f)] public float s_RankingChangeDur;
+        [FormerlySerializedAs("s_RankingChangeDur")]
+        [Tooltip("Sub PosX Tween 지속 시간."), Min(0f)]
+        public float subRankingChangeDur;
 
 
         [Header("Step Evaluation")]
+        [FormerlySerializedAs("mainevaDur")]
+        [FormerlySerializedAs("m_evaDur")]
         [Tooltip("Main Scale Tween 지속 시간. 이 시간만큼 두 번 반복.")]
-        [Min(0f)] public float m_evaDur;
+        [Min(0f)] public float mainEvaDur;
+        [FormerlySerializedAs("mainevaChangeDur")]
+        [FormerlySerializedAs("m_evaChangeDur")]
         [Tooltip("Main 숫자 변경 Tween 지속 시간.")]
-        [Min(0f)] public float m_evaChangeDur;
+        [Min(0f)] public float mainEvaChangeDur;
 
+        [FormerlySerializedAs("s_evaDur")]
         [Tooltip("Sub PosX Tween 지속 시간."), Space]
-        [Min(0f)] public float s_evaDur;
-        [Tooltip("Sub PosX Tween Ease")]
-        public Ease s_evaEase;
+        [Min(0f)] public float subEvaDur;
+        [FormerlySerializedAs("s_evaEase")] [Tooltip("Sub PosX Tween Ease")]
+        public Ease subEvaEase;
+
+        [Tooltip("Sub Text가 사라질 때 사용되는 Ease")] public Ease subFadeOutEase;
+
+
+        [Header("[ Evaluation Action ]")] 
+        [Header("Card Visual")]
+        [Min(1f)] public float cardScaleValue;
+        [Min(0f)] public float cardScaleDur;
+        public Ease cardScaleEase;
     }
 }

--- a/Assets/Scripts/Cards/ScriptableObjects/CardEvaluationAnimSO.cs
+++ b/Assets/Scripts/Cards/ScriptableObjects/CardEvaluationAnimSO.cs
@@ -11,7 +11,7 @@ namespace Cardevil.Cards.ScriptableObjects
         [VisibleOnly, SerializeField, TextArea]
         private string description = "족보 선택/카드 변경 글자 애니메이션 설정 SO입니다.";
 
-        [Header("Common")]
+        [Header("[ Common ]")]
         [FormerlySerializedAs("s_posX")]
         [Tooltip("Sub PosX")]
         [Min(30f)] public float subPosX;
@@ -20,7 +20,7 @@ namespace Cardevil.Cards.ScriptableObjects
         public float mainRankingScaleValue;
 
         
-        [Header("Ranking Changed")]
+        [Header("[ Ranking Changed ]")]
         [FormerlySerializedAs("m_RankingChangeDur"), Min(0f)]
         [Tooltip("Main Scale Tween 지속 시간. 이 시간만큼 두 번 반복.")]
         public float mainRankingChangeDur;
@@ -30,7 +30,7 @@ namespace Cardevil.Cards.ScriptableObjects
         public float subRankingChangeDur;
 
 
-        [Header("Step Evaluation")]
+        [Header("[ Step Evaluation ]")]
         [FormerlySerializedAs("mainevaDur")]
         [FormerlySerializedAs("m_evaDur")]
         [Tooltip("Main Scale Tween 지속 시간. 이 시간만큼 두 번 반복.")]
@@ -54,5 +54,8 @@ namespace Cardevil.Cards.ScriptableObjects
         [Min(1f)] public float cardScaleValue;
         [Min(0f)] public float cardScaleDur;
         public Ease cardScaleEase;
+
+        [Header("[ Etc ]")] 
+        [Min(0f)] public float clearTextDur;
     }
 }

--- a/Assets/Scripts/Itmes/Relics/RelicEffects/OnEvaluation/DamageByHandRankingEffect.cs
+++ b/Assets/Scripts/Itmes/Relics/RelicEffects/OnEvaluation/DamageByHandRankingEffect.cs
@@ -17,6 +17,8 @@ namespace Cardevil.Relics.OnEvaluation
         [SerializeField, VisibleOnly] private int damageAmount;
         [SerializeField, VisibleOnly] private float damageMultiplier;
 
+        public bool IsPlus => isPlus;
+        
         public bool CanTrigger(HandRanking currentHandRanking, IReadOnlyEvaluationResultsModel resultModel) =>
             currentHandRanking == triggerHandRanking;
 

--- a/Assets/Scripts/Itmes/Relics/RelicEffects/OnEvaluation/DamageByHpEffect.cs
+++ b/Assets/Scripts/Itmes/Relics/RelicEffects/OnEvaluation/DamageByHpEffect.cs
@@ -17,6 +17,8 @@ namespace Cardevil.Relics.OnEvaluation
         [SerializeField, VisibleOnly] private int damageAmount;
         [SerializeField, VisibleOnly] private float damageMultiplier;
         
+        public bool IsPlus => isPlus;
+        
         public bool CanTrigger(HandRanking currentHandRanking, IReadOnlyEvaluationResultsModel resultModel)
             => Managers.Game.PlayerStatus.CurrentHp == triggerHp;
 

--- a/Assets/Scripts/Itmes/Relics/RelicEffects/OnEvaluation/DamageNextByHandRankingEffect.cs
+++ b/Assets/Scripts/Itmes/Relics/RelicEffects/OnEvaluation/DamageNextByHandRankingEffect.cs
@@ -19,6 +19,8 @@ namespace Cardevil.Relics.OnEvaluation
         [SerializeField, VisibleOnly] private int damageAmount;
         [SerializeField, VisibleOnly] private float damageMultiplier;
         
+        public bool IsPlus => isPlus;
+        
         public bool CanTrigger(HandRanking currentHandRanking, IReadOnlyEvaluationResultsModel resultModel)
         {
             var h = resultModel.History;

--- a/Assets/Scripts/Itmes/Relics/RelicEffects/OnEvaluation/DamageOnEachCardEffect.cs
+++ b/Assets/Scripts/Itmes/Relics/RelicEffects/OnEvaluation/DamageOnEachCardEffect.cs
@@ -14,6 +14,8 @@ namespace Cardevil.Relics.OnEvaluation
         [SerializeField, VisibleOnly] private bool isBasedKillCount; // "적을 처치할수록, 카드의 기본 데미지가 영구히 +1 증가합니다" 플래그
         [SerializeField, VisibleOnly] private int damage;
         
+        public bool IsPlus => true;
+        
         public bool CanTrigger(HandRanking currentHandRanking, IReadOnlyEvaluationResultsModel resultModel)
             => true;
 

--- a/Assets/Scripts/Itmes/Relics/RelicEffects/OnEvaluation/DamageRandomlyEffect.cs
+++ b/Assets/Scripts/Itmes/Relics/RelicEffects/OnEvaluation/DamageRandomlyEffect.cs
@@ -18,6 +18,8 @@ namespace Cardevil.Relics.OnEvaluation
         [SerializeField, VisibleOnly] private int damageAmount;
         [SerializeField, VisibleOnly] private float damageMultiplier;
         
+        public bool IsPlus => isPlus;
+        
         public bool CanTrigger(HandRanking currentHandRanking, IReadOnlyEvaluationResultsModel resultModel)
             => RandomUtil.GetValue() < triggerPossibility;
 

--- a/Assets/Scripts/Itmes/Relics/RelicEffects/OnEvaluation/IRelicEffectOnEvaluation.cs
+++ b/Assets/Scripts/Itmes/Relics/RelicEffects/OnEvaluation/IRelicEffectOnEvaluation.cs
@@ -6,6 +6,8 @@ namespace Cardevil.Relics.OnEvaluation
 {
     public interface IRelicEffectOnEvaluation
     {
+        bool IsPlus { get; }
+        
         /// <summary>
         /// 효과 발동 가능 여부 평가.
         /// 현재 족보와 평가 결과 모델을 기반으로 조건 검증.


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 FEAT: 평가 텍스트 애니메이션 개선

## 📑 개요
<!--
   목적, 변경사항, 사용법에 대한 간략한 설명
   스크린샷이 포함될 수 있습니다.
-->
- 데미지가 클수록 애니메이션 시간이 길어집니다.

https://github.com/user-attachments/assets/c09d2227-c2c0-4a15-a23c-e27392ce1b27

- 카드 추가 데미지 효과 유물 애니메이션도 추가됐습니다.

https://github.com/user-attachments/assets/cda96375-7c35-4e10-b6f4-289cd6cc76de

---

## ⚠️알려진 문제 (Known Issues)
`EvaluationView.ClearTextAsync().Forget()` 호출 시 텍스트 애니메이션이 즉시 중단됩니다.
아직 원인을 찾지 못했습니다.

--- 

## ✅ 체크리스트
<!--
  해당 PR을 올리기 전에, 반드시 체크해야할 리스트입니다.
  [ ] : 체크안됨
  [x] : 체크됨
-->
- [x] Namespace 규칙 확인
- [x] public 함수의 경우 주석 확인
- [ ] `EvaluationView.ClearTextAsync().Forget()` 호출 시 텍스트 애니메이션이 즉시 중단 버그 해결
---
