### PR TITLE
feat: 덱 호버 시 남은 카드 표시/클릭으로 잠금

### DIFF
--- a/Assets/Resources/Prefabs/Cards/CardCanvas.prefab
+++ b/Assets/Resources/Prefabs/Cards/CardCanvas.prefab
@@ -35,7 +35,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 2, y: 24}
+  m_AnchoredPosition: {x: 2, y: 10.600006}
   m_SizeDelta: {x: 180, y: 250}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8298346020090668138
@@ -161,7 +161,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: -1}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 3, y: 16}
+  m_AnchoredPosition: {x: 3, y: 2.600006}
   m_SizeDelta: {x: 180, y: 250}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1157030513783238524
@@ -252,7 +252,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 33}
+  m_AnchoredPosition: {x: 0, y: 19.600006}
   m_SizeDelta: {x: 180, y: 250}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6574567661705165912
@@ -343,7 +343,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 1}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 1, y: 31}
+  m_AnchoredPosition: {x: 1, y: 17.600006}
   m_SizeDelta: {x: 180, y: 250}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7723730411478211102
@@ -434,7 +434,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -1, y: 20}
+  m_AnchoredPosition: {x: -1, y: 6.600006}
   m_SizeDelta: {x: 180, y: 250}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5090643654532062240
@@ -525,7 +525,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -3, y: 29}
+  m_AnchoredPosition: {x: -3, y: 15.600006}
   m_SizeDelta: {x: 180, y: 250}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8950806822034624818
@@ -616,7 +616,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 2}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -4, y: 9}
+  m_AnchoredPosition: {x: -4, y: -4.399994}
   m_SizeDelta: {x: 180, y: 250}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1365601992514717192
@@ -803,7 +803,6 @@ GameObject:
   - component: {fileID: 8105059450181348433}
   - component: {fileID: 3999442505475001593}
   - component: {fileID: 8553997053376052617}
-  - component: {fileID: 153674454222333440}
   m_Layer: 5
   m_Name: Deck Visual
   m_TagString: Untagged
@@ -837,9 +836,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 50, y: 50}
+  m_AnchoredPosition: {x: 140, y: 187.5}
   m_SizeDelta: {x: 180, y: 275}
-  m_Pivot: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3999442505475001593
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -872,50 +871,6 @@ MonoBehaviour:
   - {fileID: 8961173116923305647}
   - {fileID: 9136722855867216495}
   visualSetting: {fileID: 11400000, guid: 4b7539de82d4b4b63b8d9ff49ee71fed, type: 2}
---- !u!114 &153674454222333440
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7398948212415542158}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 0}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!1 &7497445845365728041
 GameObject:
   m_ObjectHideFlags: 0
@@ -1026,7 +981,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 2}
+  m_AnchoredPosition: {x: 0, y: -11.4}
   m_SizeDelta: {x: 180, y: 250}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3751830146633817425
@@ -1222,7 +1177,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 13}
+  m_AnchoredPosition: {x: 0, y: -0.3999939}
   m_SizeDelta: {x: 180, y: 250}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &768349402863190787
@@ -1313,7 +1268,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 3}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -5, y: 26}
+  m_AnchoredPosition: {x: -5, y: 12.600006}
   m_SizeDelta: {x: 180, y: 250}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6041764318155241117

--- a/Assets/Resources/Prefabs/UI/CardUI/DeckRemainView.prefab
+++ b/Assets/Resources/Prefabs/UI/CardUI/DeckRemainView.prefab
@@ -355,6 +355,7 @@ MonoBehaviour:
   - {fileID: 5691823281554090458}
   - {fileID: 5611854195493241416}
   - {fileID: 7809546956830108485}
+  visualSO: {fileID: 11400000, guid: 4b7539de82d4b4b63b8d9ff49ee71fed, type: 2}
 --- !u!225 &7648998667566695106
 CanvasGroup:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/ScriptableObjects/Cards/CardVisualSetting.asset
+++ b/Assets/Resources/ScriptableObjects/Cards/CardVisualSetting.asset
@@ -55,4 +55,5 @@ MonoBehaviour:
   _deckInteractionScale: 1.125
   _deckInteractionDuration: 0.09
   _deckInteractionEase: 31
+  deckRemainViewToggleDur: 0.3
   _reviveInterval: 0.4

--- a/Assets/Scripts/Cards/InStage/CardDeckVisual.cs
+++ b/Assets/Scripts/Cards/InStage/CardDeckVisual.cs
@@ -1,30 +1,36 @@
 using Cardevil.Cards.ScriptableObjects;
+using Cardevil.Utils;
 using UnityEngine;
 using System.Collections.Generic;
 using DG.Tweening;
+using System;
+using UnityEngine.EventSystems;
 
 namespace Cardevil.Cards.InStage
 {
-    public class CardDeckVisual : MonoBehaviour
+    public class CardDeckVisual : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerUpHandler, IPointerDownHandler
     {
-        /*
-        41-50
-        31-40
-        21-30
-        11-20
-        6-10
-        5
-        4
-        3
-        2
-        1
-        */
+        [SerializeField] private List<Transform> cards;
+        [SerializeField] private CardVisualSettingSO visualSetting;
+        
+        public event Action PointerEnter;
+        public event Action PointerExit;
+        public event Action PointerUp;
 
-        [SerializeField] List<Transform> cards;
-
-        [SerializeField] CardVisualSettingSO visualSetting;
-
+        private static CardDeckVisual _instance;
+        
+        public static CardDeckVisual Instance => _instance;
         public Transform Front => cards[0];
+
+        private void Awake()
+        {
+            _instance = this;
+        }
+
+        private void OnDestroy()
+        {
+            _instance = null;
+        }
 
         /// <summary>
         /// Draw, Discard 등의 상호작용이 있을 때 scale tween.
@@ -35,6 +41,33 @@ namespace Cardevil.Cards.InStage
                 .SetEase(visualSetting.DeckInteractionEase)
                 .OnComplete(() => transform.DOScale(1f, visualSetting.DeckInteractionDuration)
                 .SetEase(visualSetting.DeckInteractionEase));
+        }
+
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            LogEx.Log("OnPointerEnter");
+            PointerEnter?.Invoke();
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            LogEx.Log("OnPointerExit");
+            PointerExit?.Invoke();
+        }
+        
+        public void OnPointerDown(PointerEventData eventData)
+        {
+            LogEx.Log("OnPointerDown");
+            transform.DOScale(visualSetting.DeckInteractionScale, visualSetting.DeckInteractionDuration)
+                .SetEase(visualSetting.DeckInteractionEase);
+        }
+
+        public void OnPointerUp(PointerEventData eventData)
+        {
+            LogEx.Log("OnPointerUp");
+            PointerUp?.Invoke();
+            transform.DOScale(1f, visualSetting.DeckInteractionDuration)
+                .SetEase(visualSetting.DeckInteractionEase);
         }
     }
 }

--- a/Assets/Scripts/Cards/InStage/CardDeckVisual.cs
+++ b/Assets/Scripts/Cards/InStage/CardDeckVisual.cs
@@ -45,26 +45,22 @@ namespace Cardevil.Cards.InStage
 
         public void OnPointerEnter(PointerEventData eventData)
         {
-            LogEx.Log("OnPointerEnter");
             PointerEnter?.Invoke();
         }
 
         public void OnPointerExit(PointerEventData eventData)
         {
-            LogEx.Log("OnPointerExit");
             PointerExit?.Invoke();
         }
         
         public void OnPointerDown(PointerEventData eventData)
         {
-            LogEx.Log("OnPointerDown");
             transform.DOScale(visualSetting.DeckInteractionScale, visualSetting.DeckInteractionDuration)
                 .SetEase(visualSetting.DeckInteractionEase);
         }
 
         public void OnPointerUp(PointerEventData eventData)
         {
-            LogEx.Log("OnPointerUp");
             PointerUp?.Invoke();
             transform.DOScale(1f, visualSetting.DeckInteractionDuration)
                 .SetEase(visualSetting.DeckInteractionEase);

--- a/Assets/Scripts/Cards/InStage/Presenter/StageCardsPresenter.cs
+++ b/Assets/Scripts/Cards/InStage/Presenter/StageCardsPresenter.cs
@@ -86,12 +86,13 @@ namespace Cardevil.Cards.InStage.Presenter
         /// <returns>UI 초기화 완료 후 완료되는 <see cref="UniTask"/></returns>
         public async UniTask SetUp()
         {
+            Transform canvas = GameObject.Find("CardCanvas").transform;
+            
             // View 생성
             var views = Object.FindObjectsByType<StageCardsView>(FindObjectsSortMode.None);
             if (views is { Length: > 0 }) _view = views[0];
             else
             {
-                Transform canvas = GameObject.Find("CardCanvas").transform;
                 GameObject go = Managers.Resource.Instantiate("UI/CardUI/StageCardsView", canvas);
                 _view = go.GetComponent<StageCardsView>();
             }
@@ -109,17 +110,21 @@ namespace Cardevil.Cards.InStage.Presenter
             }
             HandChanged?.Invoke();
             
-            // Deck Remain View 생성
+            // Deck Remain View 생성 및 DeckVisual에 바인딩
             var deckRemainViews = Object.FindObjectsByType<DeckRemainView>(FindObjectsSortMode.None);
             if (views is {Length: > 0}) _deckRemainView = deckRemainViews[0];
             else
             {
-                Transform canvas = GameObject.Find("CardCanvas").transform;
                 GameObject go = Managers.Resource.Instantiate("UI/CardUI/DeckRemainView", canvas);
                 _deckRemainView = go.GetComponent<DeckRemainView>();
             }
             _deckRemainView.Init(_library, _model);
             DeckChanged += _deckRemainView.OnDeckChanged;
+
+            CardDeckVisual.Instance.PointerEnter += _deckRemainView.OnPointerEnterAtDeck;
+            CardDeckVisual.Instance.PointerExit += _deckRemainView.OnPointerExitAtDeck;
+            CardDeckVisual.Instance.PointerUp += _deckRemainView.OnPointerClickAtDeck;
+            CardDeckVisual.Instance.transform.SetAsLastSibling();
             
             await _view.EnterHandBarAsync();
             
@@ -154,6 +159,10 @@ namespace Cardevil.Cards.InStage.Presenter
         {
             // Update Async 정지
             _updateCts.Cancel();
+            
+            CardDeckVisual.Instance.PointerEnter -= _deckRemainView.OnPointerEnterAtDeck;
+            CardDeckVisual.Instance.PointerExit -= _deckRemainView.OnPointerExitAtDeck;
+            CardDeckVisual.Instance.PointerUp -= _deckRemainView.OnPointerClickAtDeck;
             
             await _view.ExitHandBarAsync();
         }

--- a/Assets/Scripts/Cards/InStage/View/DeckRemainView.cs
+++ b/Assets/Scripts/Cards/InStage/View/DeckRemainView.cs
@@ -72,7 +72,6 @@ namespace Cardevil.Cards.InStage.View
         public void OnPointerExitAtDeck()
         {
             if (_isClicked) return;
-            _isVisible = false;
             _tween?.Kill();
             
             const float targetAlpha = 0f;
@@ -87,6 +86,7 @@ namespace Cardevil.Cards.InStage.View
             {
                 canvasGroup.interactable = false;
                 canvasGroup.blocksRaycasts = false;
+                _isVisible = false;
             });
         }
 

--- a/Assets/Scripts/Cards/InStage/View/DeckRemainView.cs
+++ b/Assets/Scripts/Cards/InStage/View/DeckRemainView.cs
@@ -1,11 +1,8 @@
 using Cardevil.Cards.Data;
 using Cardevil.Cards.InStage.Model.ReadOnly;
-using Cardevil.DebugConsole;
+using Cardevil.Cards.ScriptableObjects;
 using Cardevil.Utils;
-using Cysharp.Threading.Tasks;
 using DG.Tweening;
-using System;
-using Unity.VisualScripting;
 using UnityEngine;
 
 namespace Cardevil.Cards.InStage.View
@@ -15,11 +12,13 @@ namespace Cardevil.Cards.InStage.View
     {
         [SerializeField] private CanvasGroup canvasGroup;
         [SerializeField] private CardVisualUI[] cardVisuals;
+        [SerializeField] private CardVisualSettingSO visualSO;
 
         private IReadOnlyCardLibrary _library;
         private IReadOnlyStageCardsModel _model;
 
         private bool _isVisible;
+        private bool _isClicked;
         private Tween _tween;
 
         public void Init(IReadOnlyCardLibrary library, IReadOnlyStageCardsModel model)
@@ -48,6 +47,53 @@ namespace Cardevil.Cards.InStage.View
             canvasGroup.interactable = false;
             canvasGroup.blocksRaycasts = false;
         }
+
+        public void OnPointerEnterAtDeck()
+        {
+            if (_isClicked) return;
+            _isVisible = true;
+            _tween?.Kill();
+            
+            const float targetAlpha = 1f;
+
+            canvasGroup.interactable = false;
+            
+            _tween = canvasGroup.DOFade(targetAlpha, visualSO.DeckRemainViewToggleDur)
+                .SetLink(gameObject)
+                .SetRecyclable(true);
+            
+            _tween.OnComplete(() =>
+            {
+                canvasGroup.interactable = true;
+                canvasGroup.blocksRaycasts = true;
+            });
+        }
+
+        public void OnPointerExitAtDeck()
+        {
+            if (_isClicked) return;
+            _isVisible = false;
+            _tween?.Kill();
+            
+            const float targetAlpha = 0f;
+
+            canvasGroup.interactable = false;
+            
+            _tween = canvasGroup.DOFade(targetAlpha, visualSO.DeckRemainViewToggleDur)
+                .SetLink(gameObject)
+                .SetRecyclable(true);
+            
+            _tween.OnComplete(() =>
+            {
+                canvasGroup.interactable = false;
+                canvasGroup.blocksRaycasts = false;
+            });
+        }
+
+        public void OnPointerClickAtDeck()
+        {
+            _isClicked = !_isClicked;
+        }
         
         /// <summary>
         /// 덱에 변경이 있을 때마다 UI를 업데이트함.
@@ -74,32 +120,6 @@ namespace Cardevil.Cards.InStage.View
                     cardVisuals[id].SetStateImmediate(false);
             }
         }
-        
-        public async UniTaskVoid SetVisible(bool isVisible)
-        {
-            if (_isVisible == isVisible) return;
-            _isVisible = isVisible;
-            
-            var dur = .5f;
-            var targetAlpha = isVisible ? 1 : 0;
-            
-            // 이전 트윈 정리
-            _tween?.Kill();
-
-            canvasGroup.interactable = false;
-            
-            _tween = canvasGroup.DOFade(targetAlpha, dur)
-                .SetLink(gameObject)
-                .SetRecyclable(true);
-            
-            _tween.OnComplete(() =>
-            {
-                canvasGroup.interactable = isVisible;
-                canvasGroup.blocksRaycasts = isVisible;
-            });
-
-            await _tween;
-        }
 
         private void UpdateSpriteSet(int index)
         {
@@ -124,12 +144,6 @@ namespace Cardevil.Cards.InStage.View
             }
                 
             cardVisualUI.Init(index, spriteSet);
-        }
-
-        [ContextMenu("Toggle Visible")]
-        private void ToggleVisible()
-        {
-            SetVisible(!_isVisible).Forget();
         }
     }
 }

--- a/Assets/Scripts/Cards/ScriptableObjects/CardVisualSettingSO.cs
+++ b/Assets/Scripts/Cards/ScriptableObjects/CardVisualSettingSO.cs
@@ -106,8 +106,8 @@ namespace Cardevil.Cards.ScriptableObjects
         [SerializeField] float _deckInteractionScale = 1.125f;
         [SerializeField] float _deckInteractionDuration = .09f;
         [SerializeField] Ease _deckInteractionEase = Ease.InOutBounce;
-        [Space(25)]
-
+        [Space(25)] 
+        [SerializeField] private float deckRemainViewToggleDur;
 
         [Header("[ Etc ]")]
         [SerializeField] private float _reviveInterval = .4f;
@@ -172,7 +172,9 @@ namespace Cardevil.Cards.ScriptableObjects
         public float DeckInteractionScale => _deckInteractionScale;
         public float DeckInteractionDuration => _deckInteractionDuration * SpeedFactor;
         public Ease DeckInteractionEase => _deckInteractionEase;
-        
+
+        public float DeckRemainViewToggleDur => deckRemainViewToggleDur * SpeedFactor;
+
         public float ReviveInterval => _reviveInterval * SpeedFactor;
         
         #endregion


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 FEAT: 덱 호버 시 남은 카드 표시/클릭으로 잠금 

## 📑 개요
<!--
   목적, 변경사항, 사용법에 대한 간략한 설명
   스크린샷이 포함될 수 있습니다.
-->
덱에 마우스를 올리면 남은 카드가 표시됩니다.
클릭으로 마우스를 옮겨도 표시되도록 잠금이 가능합니다.


https://github.com/user-attachments/assets/53628593-1cb3-4438-8bf5-ebad9fc51903

---

## ✏️ 변경(추가) 사항

### 1) StageCardsPresenter
- `CardDeckVisual`의 포인터 이벤트(`PointerEnter`, `PointerExit`, `PointerUp`)에 `DeckRemainView`의 대응 메서드 구독
- 스테이지 종료 시 이벤트 구독을 일괄 해제

### 2) DeckRemainView
- 내부적으로 `Tween` 인스턴스를 보관하며, 각 트리거 메서드 실행 시 `Tween?.Kill()` 호출 후 새 트윈 생성
→ 빠른 마우스 이동 시에도 정상 동작

---

## ✅ 체크리스트
<!--
  해당 PR을 올리기 전에, 반드시 체크해야할 리스트입니다.
  [ ] : 체크안됨
  [x] : 체크됨
-->
- [x] Namespace 규칙 확인
- [ ] public 함수의 경우 주석 확인
---

## 연관 PR
<!--
  (Optional)
  없는 경우 제거
-->
#61

---

