### PR TITLE
FEAT: DirectionFlag에 상하/좌우 추가 & CardData에 DirectionFlag 함께 저장

### DIFF
--- a/Assets/Scripts/Cards/Data/InStage/CardData.cs
+++ b/Assets/Scripts/Cards/Data/InStage/CardData.cs
@@ -53,6 +53,7 @@ namespace Cardevil.Cards.Data.InStage
         // Move Card
         public int Length => length;
         public SelectState<Direction> DirectionSelectState => directionSelectState;
+        public DirectionFlag DirectionFlag => directionFlag;
 
         #endregion
         

--- a/Assets/Scripts/Cards/Data/InStage/CardData.cs
+++ b/Assets/Scripts/Cards/Data/InStage/CardData.cs
@@ -23,6 +23,7 @@ namespace Cardevil.Cards.Data.InStage
         [Header("Move Card")]
         [SerializeField, VisibleOnly] private int length;
         [SerializeField, VisibleOnly] private SelectState<Direction> directionSelectState;
+        [SerializeField, VisibleOnly] private DirectionFlag directionFlag;
         
         /// <summary>
         /// 스테이지 입장 전 상태로 초기화합니다.
@@ -70,6 +71,7 @@ namespace Cardevil.Cards.Data.InStage
 
             private int _length = 1;
             private readonly List<Direction?> _directionSelectables = new();
+            private DirectionFlag _directionFlag = DirectionFlag.None;
             
             private EnhancementData _currentEnhancement;
             
@@ -150,16 +152,22 @@ namespace Cardevil.Cards.Data.InStage
                 if (_kind == CardKind.Attack)
                     numberSelectState = new(_numberSelectables);
                 else if (_kind == CardKind.Move)
+                {
                     directionSelectState = new(_directionSelectables);
+                    
+                    // Direction Flag 확정
+                    foreach (var dir in directionSelectState.Selectables)
+                        _directionFlag |= dir.value.ToDirectionFlag();
+                }
 
-                return new CardData(_id, _kind, _currentEnhancement, _color, _damageMultiplier, numberSelectState, _length, directionSelectState);
+                return new CardData(_id, _kind, _currentEnhancement, _color, _damageMultiplier, numberSelectState, _length, directionSelectState, _directionFlag);
             }
         }
         
         private CardData(
             int id, CardKind kind, EnhancementData currentEnhancement, 
             CardColor color, float damageMultiplier, SelectState<int> numberSelectState, 
-            int length, SelectState<Direction> directionSelectState)
+            int length, SelectState<Direction> directionSelectState, DirectionFlag directionFlag)
         {
             this.id = id;
             this.kind = kind;
@@ -171,6 +179,7 @@ namespace Cardevil.Cards.Data.InStage
             
             this.length = length;
             this.directionSelectState = directionSelectState;
+            this.directionFlag = directionFlag;
         }
 
         #endregion

--- a/Assets/Scripts/Utils/Direction.cs
+++ b/Assets/Scripts/Utils/Direction.cs
@@ -29,6 +29,9 @@ namespace Cardevil.Utils.Directions
         Right = 1 << 1,
         Down = 1 << 2,
         Left = 1 << 3,
+        
+        UpDown = Up | Down,
+        LeftRight = Left | Right,
         All = Up | Right | Down | Left
     }
     

--- a/Assets/Scripts/Utils/Direction.cs
+++ b/Assets/Scripts/Utils/Direction.cs
@@ -102,8 +102,16 @@ namespace Cardevil.Utils.Directions
                 _ => throw new ArgumentOutOfRangeException(nameof(direction), direction, null)
             };
         }
-        
 
-        
+        public static string ToCustomString(this DirectionFlag directionFlag)
+        {
+            return directionFlag switch
+            {
+                DirectionFlag.UpDown => "UpDown",
+                DirectionFlag.LeftRight => "LeftRight",
+                DirectionFlag.All => "All",
+                _ => directionFlag.ToString()
+            };
+        }
     }
 }


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 FEAT: DirectionFlag에 상하/좌우 추가 & CardData에 DirectionFlag 함께 저장

## 📑 개요
<!--
   목적, 변경사항, 사용법에 대한 간략한 설명
   스크린샷이 포함될 수 있습니다.
-->
`CardData`가 `DirectionFlag`를 통해 '상하', '좌우', '네 방향'을 저장합니다.

---

## ✏️ 변경(추가) 사항

### 1) DirectionFlag
기존 DirectionFlag에 `UpDown`, `LeftRight`를 추가했습니다.



### 2) CardData
**CardData가 빌드 과정에서 DirectionFlag 함께 저장합니다.**

```C#
else if (_kind == CardKind.Move)
{
    /*...*/
    
    // Direction Flag 확정
    foreach (var dir in directionSelectState.Selectables)
        _directionFlag |= dir.value.ToDirectionFlag();
}
```

---