### PR TITLE
FEAT : 콘솔 폰트 사이즈 조절 기능 추가

### DIFF
--- a/Assets/Prefabs/UI/ConsoleUI.prefab
+++ b/Assets/Prefabs/UI/ConsoleUI.prefab
@@ -49,6 +49,8 @@ MonoBehaviour:
   _isInitialized: 0
   _isOpen: 0
   _useAutoComplete: 1
+  autoScrollToBottomOnNewMessage: 1
+  autoScrollToBottomOnNewPrint: 1
   _toggleConsoleAction:
     m_Name: Toggle Console
     m_Type: 0
@@ -64,6 +66,57 @@ MonoBehaviour:
       m_Processors: 
       m_Groups: 
       m_Action: Toggle Console
+      m_Flags: 0
+    m_Flags: 0
+  _ctrlAction:
+    m_Name: Ctrl
+    m_Type: 0
+    m_ExpectedControlType: 
+    m_Id: 46dd8971-620f-4c1c-9a77-e8db75bc7913
+    m_Processors: 
+    m_Interactions: 
+    m_SingletonActionBindings:
+    - m_Name: 
+      m_Id: 7acf4c4b-042e-4757-afef-3d9fd8450686
+      m_Path: <Keyboard>/ctrl
+      m_Interactions: 
+      m_Processors: 
+      m_Groups: 
+      m_Action: Ctrl
+      m_Flags: 0
+    m_Flags: 0
+  _sizeUpAction:
+    m_Name: Size Up
+    m_Type: 0
+    m_ExpectedControlType: 
+    m_Id: 36cc373b-43bd-42d8-80cc-caed5f7bbd9e
+    m_Processors: 
+    m_Interactions: 
+    m_SingletonActionBindings:
+    - m_Name: 
+      m_Id: be4dd86d-1022-4cb2-8e9d-2ffeb53f55d0
+      m_Path: <Keyboard>/equals
+      m_Interactions: 
+      m_Processors: 
+      m_Groups: 
+      m_Action: Size Up
+      m_Flags: 0
+    m_Flags: 0
+  _sizeDownAction:
+    m_Name: Size Down
+    m_Type: 0
+    m_ExpectedControlType: 
+    m_Id: 1dffd75a-8689-4bd6-a950-3c7c82ab1447
+    m_Processors: 
+    m_Interactions: 
+    m_SingletonActionBindings:
+    - m_Name: 
+      m_Id: bfa4f9a4-5eb3-42f3-9741-50f1fdfb6e0b
+      m_Path: <Keyboard>/minus
+      m_Interactions: 
+      m_Processors: 
+      m_Groups: 
+      m_Action: Size Down
       m_Flags: 0
     m_Flags: 0
   minSize: {x: 360, y: 200}

--- a/Assets/Scripts/DebugConsole/ConsoleUI.cs
+++ b/Assets/Scripts/DebugConsole/ConsoleUI.cs
@@ -32,6 +32,9 @@ namespace Cardevil.DebugConsole
         [SerializeField] private bool autoScrollToBottomOnNewPrint = true;
         [Header("단축키 설정")]
         [SerializeField] InputAction _toggleConsoleAction;
+        [SerializeField] InputAction _ctrlAction;
+        [SerializeField] InputAction _sizeUpAction;
+        [SerializeField] InputAction _sizeDownAction;
         // [SerializeField] InputAction _autoCompleteConsoleAction;
         [Header("크기 제한")]
         [SerializeField] private Vector2 minSize = new Vector2(360, 200);
@@ -177,6 +180,24 @@ namespace Cardevil.DebugConsole
             {
                 _toggleConsoleAction.performed += OnToggleKeyPressed;
                 _toggleConsoleAction.Enable();
+                _ctrlAction?.Enable();
+                _sizeUpAction?.Enable();
+                _sizeDownAction?.Enable();
+                _sizeUpAction.performed += ctx =>
+                {
+                    if (_ctrlAction != null && _ctrlAction.IsPressed())
+                    {
+                        FontSizeUp();
+                    }
+                };
+                _sizeDownAction.performed += ctx =>
+                {
+                    if (_ctrlAction != null && _ctrlAction.IsPressed())
+                    {
+                        FontSizeDown();
+                    }
+                    
+                };
             }
             else
             {
@@ -185,6 +206,17 @@ namespace Cardevil.DebugConsole
                     if (c == '`')
                     {
                         Toggle();
+                    }
+                    if (Keyboard.current.ctrlKey.isPressed)
+                    {
+                        if (c == '+')
+                        {
+                            FontSizeUp();
+                        }
+                        else if (c == '-')
+                        {
+                            FontSizeDown();
+                        }
                     }
                 };
             }
@@ -369,6 +401,25 @@ namespace Cardevil.DebugConsole
         public void SetOpacity(float opacity)
         {
             root.style.opacity = Mathf.Clamp01(opacity);
+        }
+        
+        public void FontSizeUp(int step = 2)
+        {
+            float newSize = root.resolvedStyle.fontSize + step;
+            Message(MessageType.Gray,$"Font size up to {newSize}");
+            root.style.fontSize = newSize;
+            previewContainer.MarkDirtyRepaint(); 
+
+        }
+
+        public void FontSizeDown(int step = 2)
+        {
+            float newSize = root.resolvedStyle.fontSize - step;
+            if (newSize < 6)
+                newSize = 6;
+            Message(MessageType.Gray,$"Font size down to {newSize}");
+            root.style.fontSize = newSize;
+            previewContainer.MarkDirtyRepaint(); 
         }
         
         /// <summary>

--- a/Assets/UI Toolkit/DebugConsole/console.uss
+++ b/Assets/UI Toolkit/DebugConsole/console.uss
@@ -113,20 +113,10 @@
     padding: 4px;
 }
 
-#PreviewContainer .unity-scroll-view__content-container {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 6px;
-    align-items: flex-start;
-    min-height: 24px;
-    max-height: 48px;
-}
 
 .preview .suggest {
     padding: 2px 6px;
     border-radius: 4px;
-    font-size: 12px;
     min-height: 20px;
     background-color: rgb(35, 42, 47);
     color: rgb(137, 255, 163);
@@ -190,10 +180,16 @@
     display: none;
 }
 
-/* 프리뷰: 가로 스크롤만 */
+
 #PreviewContainer {
-    overflow: hidden; /* 세로 스크롤 숨김 */
+    overflow: visible;
+    flex-shrink: 0;
+    min-height: 34px;
+    height: auto;
+    flex-grow: 0;
+    padding-bottom: 12px;
 }
+
 /* 프리뷰의 컨텐츠를 가로로 배치 + 줄바꿈 없음 */
 #PreviewContainer .unity-scroll-view__content-container {
     display: flex;


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 FEAT : 콘솔 폰트 사이즈 조절 기능 추가

## 📑 개요
<!--
   목적, 변경사항, 사용법에 대한 간략한 설명
   스크린샷이 포함될 수 있습니다.
-->

콘솔창의 글씨 크기를 조절하는 기능을 넣었습니다.

Tile과 기타 글씨의 크기는 안바뀔 수 있습니다.


---

## 📖사용 방법
<!--
  (Optional)
  다른 사람이 사용하지 않아도 되는 경우 없어도 됩니다.
-->
<img width="484" height="191" alt="image" src="https://github.com/user-attachments/assets/c4849419-8c4b-4b19-9d5e-8a2e3d85c2c7" />


위 부분에서 단축키설정이 가능합니다.


### 기본값
- 키우기 : ctrl+ '+'
- 줄이기 : ctrl + '-'

---

## ✅ 체크리스트
<!--
  해당 PR을 올리기 전에, 반드시 체크해야할 리스트입니다.
  [ ] : 체크안됨
  [x] : 체크됨
-->
- [x] Namespace 규칙 확인
- [x] public 함수의 경우 주석 확인
---


