### PR TITLE
FEAT : ExecEvent에 CancellationToken 추가

### DIFF
--- a/Assets/Scripts/Events/ExecEvent/ExecDynamicEventBus.cs
+++ b/Assets/Scripts/Events/ExecEvent/ExecDynamicEventBus.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using Cysharp.Threading.Tasks;
 using Cardevil.Events.Core;
+using Cardevil.Utils;
 
 namespace Cardevil.Events.ExecEvents
 {
@@ -74,19 +76,31 @@ namespace Cardevil.Events.ExecEvents
         /// await ExecEventBus&lt;MyEventArgs&gt;.Invoke(args);
         /// </code>
         /// <param name="eventArgs"></param>
-        public static async UniTask Invoke(TEvent eventArgs)
+        /// <param name="cancellationToken"></param>
+        public static async UniTask Invoke(TEvent eventArgs, CancellationToken cancellationToken = default)
         {
             _execQueue.Clear();
             _execQueue.SetCapacity(_handlers.Count);
-            if(eventArgs.BreakChain) 
+            if(eventArgs.BreakChain || cancellationToken.IsCancellationRequested)
             {
+                LogEx.Log("Invocation cancelled or chain broken before invocation.");
                 return;
             }
             foreach (var handler in _handlers)
             {
+                if(cancellationToken.IsCancellationRequested)
+                {
+                    LogEx.Log("Invocation cancelled.");
+                    break;
+                }
+                if(eventArgs.BreakChain) 
+                {
+                    LogEx.Log("Invocation chain broken.");
+                    break;
+                }
                 handler.Invoke(_execQueue, eventArgs);
             }
-            await _execQueue.ExecuteAll(eventArgs);
+            await _execQueue.ExecuteAll(eventArgs, cancellationToken);
         }
 
         /// <summary>

--- a/Assets/Scripts/Events/ExecEvent/ExecEventBus.cs
+++ b/Assets/Scripts/Events/ExecEvent/ExecEventBus.cs
@@ -1,4 +1,5 @@
 ﻿using Cardevil.Utils;
+using System.Threading;
 using Cysharp.Threading.Tasks;
 
 namespace Cardevil.Events.ExecEvents
@@ -92,12 +93,23 @@ namespace Cardevil.Events.ExecEvents
         /// await ExecEventBus&lt;MyEventArgs&gt;.InvokeSequentially(args);
         /// </code>
         /// <param name="args"></param>
-        public static async UniTask InvokeSequentially(TEvent args)
+        /// <param name="cancellationToken"></param>
+        public static async UniTask InvokeSequentially(TEvent args, CancellationToken cancellationToken = default)
         {
             LogEx.Log("Invoking Dynamic Event Bus");
-            await ExecDynamicEventBus<TEvent>.Invoke(args);
+            await ExecDynamicEventBus<TEvent>.Invoke(args, cancellationToken);
+            if (cancellationToken.IsCancellationRequested)
+            {
+                LogEx.Log("Sequential Event Bus invocation cancelled.");
+                return;
+            }
+            if (args.BreakChain)
+            {
+                LogEx.Log("Sequential Event Bus invocation chain broken.");
+                return;
+            }
             LogEx.Log("Invoking Static Event Bus");
-            await ExecStaticEventBus<TEvent>.Invoke(args);
+            await ExecStaticEventBus<TEvent>.Invoke(args, cancellationToken);
         }
 
         /// <summary>
@@ -112,7 +124,8 @@ namespace Cardevil.Events.ExecEvents
         /// await ExecEventBus&lt;MyEventArgs&gt;.InvokeMerged(args);
         /// </code>
         /// <param name="args"></param>
-        public static async UniTask InvokeMerged(TEvent args)
+        /// <param name="cancellationToken"></param>
+        public static async UniTask InvokeMerged(TEvent args, CancellationToken cancellationToken = default)
         {
             LogEx.Log("Invoking Merged Event Bus");
             _isMergedExecuting = true;
@@ -129,43 +142,48 @@ namespace Cardevil.Events.ExecEvents
                 // 두 큐를 병합 정렬 방식으로 실행
                 while (dynamicIndex < dynamicQueue.Count && staticIndex < staticQueue.Count)
                 {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        LogEx.Log("Merged Event Bus invocation cancelled.");
+                        break;
+                    }
+                    if (args.BreakChain)
+                    {
+                        LogEx.Log("Merged Event Bus invocation chain broken.");
+                        break;
+                    }
+                    
                     var dynamicAction = dynamicQueue[dynamicIndex];
                     var staticAction = staticQueue[staticIndex];
                     
                     if (dynamicAction.CompareTo(staticAction) <= 0)
                     {
-                        LogEx.Log($"({dynamicAction._primaryPriority})Executing Dynamic action {dynamicAction.action}");
-                        await dynamicAction.action.Invoke(args);
+                        // LogEx.Log($"({dynamicAction._primaryPriority})Executing Dynamic action {dynamicAction.action}");
+                        await dynamicAction.action.Invoke(args, cancellationToken);
                         dynamicIndex++;
                     }
                     else
                     {
-                        LogEx.Log($"({staticAction._primaryPriority})Executing Static action {staticAction.action}");
-                        await staticAction.action.Invoke(args);
+                        // LogEx.Log($"({staticAction._primaryPriority})Executing Static action {staticAction.action}");
+                        await staticAction.action.Invoke(args, cancellationToken);
                         staticIndex++;
-                    }
-                    
-                    if (args.BreakChain)
-                    {
-                        LogEx.Log("Merged Event Bus chain broken");
-                        break;
                     }
                 }
                 
                 // 남은 동적 작업 실행
-                while (dynamicIndex < dynamicQueue.Count && !args.BreakChain)
+                while (dynamicIndex < dynamicQueue.Count && !cancellationToken.IsCancellationRequested && !args.BreakChain)
                 {
                     var dynamicAction = dynamicQueue[dynamicIndex];
-                    LogEx.Log($"({dynamicAction._primaryPriority})Executing Dynamic action {dynamicAction.action}");
-                    await dynamicAction.action.Invoke(args);
+                    // LogEx.Log($"({dynamicAction._primaryPriority})Executing Dynamic action {dynamicAction.action}");
+                    await dynamicAction.action.Invoke(args, cancellationToken);
                     dynamicIndex++;
                 }
                 // 남은 정적 작업 실행
-                while (staticIndex < staticQueue.Count && !args.BreakChain)
+                while (staticIndex < staticQueue.Count && !cancellationToken.IsCancellationRequested && !args.BreakChain)
                 {
                     var staticAction = staticQueue[staticIndex];
-                    LogEx.Log($"({staticAction._primaryPriority})Executing Static action {staticAction.action}");
-                    await staticAction.action.Invoke(args);
+                    // LogEx.Log($"({staticAction._primaryPriority})Executing Static action {staticAction.action}");
+                    await staticAction.action.Invoke(args, cancellationToken);
                     staticIndex++;
                 }
             }

--- a/Assets/Scripts/Events/ExecEvent/ExecEventUtil.cs
+++ b/Assets/Scripts/Events/ExecEvent/ExecEventUtil.cs
@@ -1,6 +1,7 @@
 ﻿using Cardevil.Utils;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Cysharp.Threading.Tasks;
 
 
@@ -11,8 +12,8 @@ using UnityEditor;
 namespace Cardevil.Events.ExecEvents
 {
     public delegate void ExecEventHandler<TEvent>(ExecQueue<TEvent> queue, TEvent eventArgs) where TEvent : ExecEventArgs<TEvent>, new();
-    public delegate UniTask ExecAction<TEvent>(TEvent eventArgs) where TEvent : ExecEventArgs<TEvent>, new();
-    
+    public delegate UniTask ExecAction<TEvent>(TEvent eventArgs, CancellationToken cancellationToken) where TEvent : ExecEventArgs<TEvent>, new();
+
     /// <summary>
     /// 우선순위 실행 이벤트 유틸리티 클래스
     /// </summary>

--- a/Assets/Scripts/Events/ExecEvent/ExecQueue.cs
+++ b/Assets/Scripts/Events/ExecEvent/ExecQueue.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
+using System.Threading;
 using UnityEngine.Pool;
 
 namespace Cardevil.Events.ExecEvents
@@ -260,7 +261,8 @@ namespace Cardevil.Events.ExecEvents
         /// 모든 액션을 우선순위에 따라 실행합니다.
         /// </summary>
         /// <param name="eventArgs"></param>
-        public async UniTask ExecuteAll(TEventArgs eventArgs)
+        /// <param name="cancellationToken"></param>
+        public async UniTask ExecuteAll(TEventArgs eventArgs, CancellationToken cancellationToken = default)
         {
             if (_dirty)
             {
@@ -277,14 +279,19 @@ namespace Cardevil.Events.ExecEvents
                 }
                 foreach (var wrapper in _snapshot)
                 {
-                    LogEx.Log($"({wrapper._primaryPriority})Executing action {wrapper.action}");
-                    await wrapper.action.Invoke(eventArgs);
-                    
-                    if (eventArgs.BreakChain)
+                    if (cancellationToken.IsCancellationRequested)
                     {
-                        LogEx.Log($"[ExecQueue<{typeof(TEventArgs).Name}>] Chain broken at action {wrapper.action}");
+                        LogEx.Log($"({wrapper._primaryPriority})Cancelled by token at action {wrapper.action}");
                         break;
                     }
+                    if (eventArgs.BreakChain)
+                    {
+                        LogEx.Log($"({wrapper._primaryPriority}) Chain broken at action {wrapper.action}");
+                        break;
+                    }
+                    
+                    LogEx.Log($"({wrapper._primaryPriority})Executing action {wrapper.action}");
+                    await wrapper.action.Invoke(eventArgs, cancellationToken);
                 }
             }
             finally

--- a/Assets/Scripts/Events/ExecEvent/ExecStaticEventBus.cs
+++ b/Assets/Scripts/Events/ExecEvent/ExecStaticEventBus.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using Cysharp.Threading.Tasks;
 
 namespace Cardevil.Events.ExecEvents
@@ -102,9 +103,10 @@ namespace Cardevil.Events.ExecEvents
         /// await ExecStaticEventBus&lt;MyEventArgs&gt;.Invoke(args);
         /// </code>
         /// <param name="eventArgs"></param>
-        public static async UniTask Invoke(TEvent eventArgs)
+        /// <param name="cancellationToken"></param>
+        public static async UniTask Invoke(TEvent eventArgs, CancellationToken cancellationToken = default)
         {
-            await _execQueue.ExecuteAll(eventArgs);
+            await _execQueue.ExecuteAll(eventArgs, cancellationToken);
         }
         
         public static ExecQueue<TEvent> GetExecQueue()

--- a/Assets/Scripts/Ingame/Field/FieldWall.cs
+++ b/Assets/Scripts/Ingame/Field/FieldWall.cs
@@ -1,6 +1,7 @@
 using Cardevil.Events;
 using Cardevil.Events.ExecEvents;
 using Cysharp.Threading.Tasks;
+using System.Threading;
 using UnityEngine;
 
 namespace Cardevil.Ingame.Field
@@ -20,7 +21,7 @@ namespace Cardevil.Ingame.Field
         }
         
         
-        private async UniTask OnPlayerHealthChanged(PlayerHealthChangeArgs args)
+        private async UniTask OnPlayerHealthChanged(PlayerHealthChangeArgs args, CancellationToken cancellationToken)
         {
             for (int i = 0; i < _walls.Length; i++)
             {


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 FEAT : ExecEvent에 CancellationToken 추가

## 📑 개요
<!--
   목적, 변경사항, 사용법에 대한 간략한 설명
   스크린샷이 포함될 수 있습니다.
-->

ExecEvent를 실행할때 CancellationToken 을 넘겨 줄 수 있도록 했습니다.

---

## 📖사용 방법
<!--
  (Optional)
  다른 사람이 사용하지 않아도 되는 경우 없어도 됩니다.
-->

CancellationToken 는 현재 **외부에서** 취소되도록만 설계했습니다.
이벤트 체인 내부에서 취소하는 것은 기존의 `args.BreakChain`을 사용해주세요


---
## ⭐특징 및 주의사항
<!--
(Optional)
  추가적으로 설명할 사항들입니다.
-->

- 기존에 등록하던 함수에 CancelationToken을 받아 오도록 추가해주어야합니다.

> 기존 코드
```cs
private async UniTask OnPlayerHealthChanged(PlayerHealthChangeArgs args)
{
    for (int i = 0; i < _walls.Length; i++)
    {
        if (_walls[i] != null)
        {
            bool isActive = i < args.ModifiedHealth;
            _walls[i].SetActive(isActive);
        }
    }
    await UniTask.CompletedTask;
}
```

> 변경 코드
```cs
private async UniTask OnPlayerHealthChanged(PlayerHealthChangeArgs args, CancellationToken cancellationToken = default)
{
    for (int i = 0; i < _walls.Length; i++)
    {
        if (_walls[i] != null)
        {
            bool isActive = i < args.ModifiedHealth;
            _walls[i].SetActive(isActive);
        }
    }
    await UniTask.CompletedTask;
}
```

--- 

## ✅ 체크리스트
<!--
  해당 PR을 올리기 전에, 반드시 체크해야할 리스트입니다.
  [ ] : 체크안됨
  [x] : 체크됨
-->
- [x] Namespace 규칙 확인
- [x] public 함수의 경우 주석 확인
---

