### PR TITLE
FIX : Forget 사용시 중간에 인자가 Dispose되던 문제 수정

### DIFF
--- a/Assets/Scripts/Dungeon/DungeonManager.cs
+++ b/Assets/Scripts/Dungeon/DungeonManager.cs
@@ -203,9 +203,9 @@ namespace Cardevil.Dungeon
                     }
                     
                     // 이벤트 발생
-                    using var exitArgs = NodeExitedEventArgs.Get();
+                    var exitArgs = NodeExitedEventArgs.Get();
                     exitArgs.Init(currentNode, exitInfo);
-                    ExecEventBus<NodeExitedEventArgs>.InvokeMerged(exitArgs).Forget();
+                    ExecEventBus<NodeExitedEventArgs>.InvokeMergedAndDispose(exitArgs).Forget();
                 }
                 
                 // 이전 노드로 저장
@@ -235,9 +235,9 @@ namespace Cardevil.Dungeon
             }
             
             // 이벤트 발생
-            using var enterArgs = NodeEnteredEventArgs.Get();
+            var enterArgs = NodeEnteredEventArgs.Get();
             enterArgs.Init(node);
-            ExecEventBus<NodeEnteredEventArgs>.InvokeMerged(enterArgs).Forget();
+            ExecEventBus<NodeEnteredEventArgs>.InvokeMergedAndDispose(enterArgs).Forget();
             
             if (DoInstantClear)
             {
@@ -294,9 +294,9 @@ namespace Cardevil.Dungeon
             }
             
             // 이벤트 발생
-            using var args = NodeExitedEventArgs.Get();
+            var args = NodeExitedEventArgs.Get();
             args.Init(node, exitInfo);
-            ExecEventBus<NodeExitedEventArgs>.InvokeMerged(args).Forget();
+            ExecEventBus<NodeExitedEventArgs>.InvokeMergedAndDispose(args).Forget();
         }
         
         /// <summary>

--- a/Assets/Scripts/Events/ExecEvent/ExecDynamicEventBus.cs
+++ b/Assets/Scripts/Events/ExecEvent/ExecDynamicEventBus.cs
@@ -103,6 +103,12 @@ namespace Cardevil.Events.ExecEvents
             await _execQueue.ExecuteAll(eventArgs, cancellationToken);
         }
 
+        public static async UniTask InvokeAndDispose(TEvent eventArgs,  CancellationToken cancellationToken = default)
+        {
+            await Invoke(eventArgs, cancellationToken);
+            eventArgs.Dispose();
+        }
+        
         /// <summary>
         /// 모든 핸들러를 Invoke한 후, 해당 큐를 반환합니다.
         /// </summary>
@@ -118,6 +124,8 @@ namespace Cardevil.Events.ExecEvents
             _execQueue.SortByPriority();
             return _execQueue;
         }
+        
+        
 
 
 

--- a/Assets/Scripts/Events/ExecEvent/ExecEventBus.cs
+++ b/Assets/Scripts/Events/ExecEvent/ExecEventBus.cs
@@ -86,7 +86,8 @@ namespace Cardevil.Events.ExecEvents
         }
         
         /// <summary>
-        /// 동적 이벤트를 호출한 뒤, 정적 이벤트를 호출합니다.
+        /// 동적 이벤트를 호출한 뒤, 정적 이벤트를 호출합니다. <br/>
+        /// Forget을 사용할 경우 대신 <see cref="InvokeSequentially(TEvent, CancellationToken)"/>를 사용하세요.
         /// </summary>
         /// <code>
         /// using var args = new MyEventArgs { ... };
@@ -114,7 +115,8 @@ namespace Cardevil.Events.ExecEvents
 
         /// <summary>
         /// 동적 이벤트와 정적 이벤트를 병합하여 우선순위에 따라 호출합니다.
-        /// 두 큐를 병합 정렬(merge sort) 방식으로 실행합니다.
+        /// 두 큐를 병합 정렬(merge sort) 방식으로 실행합니다. <br/>
+        /// Forget을 사용할 경우 대신 <see cref="InvokeMerged(TEvent, CancellationToken)"/>를 사용하세요.
         /// </summary>
         /// <remarks>
         /// 같은 우선순위일 경우, 동적 이벤트가 먼저 실행됩니다.
@@ -193,6 +195,29 @@ namespace Cardevil.Events.ExecEvents
             }
             
             LogEx.Log("Merged Event Bus Invocation Complete");
+        }
+
+        /// <summary>
+        /// 동적 이벤트를 호출한 뒤, 정적 이벤트를 호출하고, 인자를 Dispose합니다.
+        /// </summary>
+        /// <param name="args"></param>
+        /// <param name="cancellationToken"></param>
+        public static async UniTask InvokeSequentiallyAndDispose(TEvent args, CancellationToken cancellationToken = default)
+        {
+            await InvokeSequentially(args, cancellationToken);
+            args.Dispose();
+            
+        }
+        
+        /// <summary>
+        /// 동적 이벤트와 정적 이벤트를 병합하여 우선순위에 따라 호출하고, 인자를 Dispose합니다.
+        /// </summary>
+        /// <param name="args"></param>
+        /// <param name="cancellationToken"></param>
+        public static async UniTask InvokeMergedAndDispose(TEvent args, CancellationToken cancellationToken = default)
+        {
+            await InvokeMerged(args, cancellationToken);
+            args.Dispose();
         }
     }
 }

--- a/Assets/Scripts/Events/ExecEvent/ExecStaticEventBus.cs
+++ b/Assets/Scripts/Events/ExecEvent/ExecStaticEventBus.cs
@@ -109,6 +109,12 @@ namespace Cardevil.Events.ExecEvents
             await _execQueue.ExecuteAll(eventArgs, cancellationToken);
         }
         
+        public static async UniTask InvokeAndDispose(TEvent eventArgs, CancellationToken cancellationToken = default)
+        {
+            await _execQueue.ExecuteAll(eventArgs, cancellationToken);
+            eventArgs.Dispose();
+        }
+        
         public static ExecQueue<TEvent> GetExecQueue()
         {
             return _execQueue;

--- a/Assets/Scripts/Ingame/PlayerStatus.cs
+++ b/Assets/Scripts/Ingame/PlayerStatus.cs
@@ -55,12 +55,12 @@ namespace Cardevil.Ingame
             get => _currentHP;
             set
             {
-                using(PlayerHealthChangeArgs args = PlayerHealthChangeArgs.Get())
-                {
-                    args.Init(_currentHP, value);
-                    ExecEventBus<PlayerHealthChangeArgs>.InvokeMerged(args).Forget();
-                    _currentHP = args.ModifiedHealth;
-                }
+                PlayerHealthChangeArgs args = PlayerHealthChangeArgs.Get();
+                
+                args.Init(_currentHP, value);
+                ExecEventBus<PlayerHealthChangeArgs>.InvokeMergedAndDispose(args).Forget();
+                _currentHP = args.ModifiedHealth;
+                
             }
         }
         public int MaxHp
@@ -72,14 +72,14 @@ namespace Cardevil.Ingame
         public int Shield
         {
             get => _shield;
-            set 
+            set
             {
-                using(PlayerShieldChangeArgs args = PlayerShieldChangeArgs.Get())
-                {
-                    args.Init(_shield, value);
-                    ExecEventBus<PlayerShieldChangeArgs>.InvokeMerged(args).Forget();
-                    _shield = args.ModifiedShield;
-                }
+                PlayerShieldChangeArgs args = PlayerShieldChangeArgs.Get();
+                
+                args.Init(_shield, value);
+                ExecEventBus<PlayerShieldChangeArgs>.InvokeMergedAndDispose(args).Forget();
+                _shield = args.ModifiedShield;
+                
             }
         }
 
@@ -95,12 +95,10 @@ namespace Cardevil.Ingame
             get => _rerollTicket;
             set
             {
-                using (RerollTicketChangeArgs args = RerollTicketChangeArgs.Get())
-                {
-                    args.Init(_rerollTicket, value);
-                    ExecEventBus<RerollTicketChangeArgs>.InvokeMerged(args).Forget();
-                    _rerollTicket = args.ModifiedTicket;
-                }
+                RerollTicketChangeArgs args = RerollTicketChangeArgs.Get();
+                args.Init(_rerollTicket, value);
+                ExecEventBus<RerollTicketChangeArgs>.InvokeMergedAndDispose(args).Forget();
+                _rerollTicket = args.ModifiedTicket;
             }
         }
         
@@ -162,12 +160,12 @@ namespace Cardevil.Ingame
         {
             if (broadcast)
             {
-                using(PlayerHealthChangeArgs args = PlayerHealthChangeArgs.Get())
-                {
-                    args.Init(_currentHP, hp);
-                    ExecEventBus<PlayerHealthChangeArgs>.InvokeMerged(args).Forget();
-                    _currentHP = args.NewHealth;
-                }
+                PlayerHealthChangeArgs args = PlayerHealthChangeArgs.Get();
+                
+                args.Init(_currentHP, hp);
+                ExecEventBus<PlayerHealthChangeArgs>.InvokeMergedAndDispose(args).Forget();
+                _currentHP = args.NewHealth;
+                
             }
             else
             {
@@ -177,12 +175,10 @@ namespace Cardevil.Ingame
         
         public void BroadcastInitialStatus()
         {
-            using(PlayerHealthChangeArgs args = PlayerHealthChangeArgs.Get())
-            {
-                args.Init(_currentHP, _currentHP);
-                args.IsJustBroadcast = true;
-                ExecEventBus<PlayerHealthChangeArgs>.InvokeMerged(args).Forget();
-            }
+            PlayerHealthChangeArgs args = PlayerHealthChangeArgs.Get();
+            args.Init(_currentHP, _currentHP);
+            args.IsJustBroadcast = true;
+            ExecEventBus<PlayerHealthChangeArgs>.InvokeMergedAndDispose(args).Forget();
         }
         
         public void SetUpNewGame(GameSave currentSave)


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 FIX : Forget 사용시 중간에 인자가 Dispose되던 문제 수정

## 📑 개요
<!--
   목적, 변경사항, 사용법에 대한 간략한 설명
   스크린샷이 포함될 수 있습니다.
-->


await를 사용하지 않고 Forget시 arg가 dispose되지 않던 문제를 수정했습니다

## 📖사용 방법
<!--
  (Optional)
  다른 사람이 사용하지 않아도 되는 경우 없어도 됩니다.
-->

Forget을 사용하는 경우 using을 사용하면 안됩니다.

> 기존코드
```cs
using var enterArgs = NodeEnteredEventArgs.Get(); // using을 사용하여 자동 Dispose
enterArgs.Init(node);
ExecEventBus<NodeEnteredEventArgs>.InvokeMerged(enterArgs).Forget(); 
// 이 스코프 종료시 arg가 Dispose됨!
```

> 개선코드

```cs
var enterArgs = NodeEnteredEventArgs.Get(); // using을 사용하지 않고, 직접 Dispose 관리
enterArgs.Init(node);
ExecEventBus<NodeEnteredEventArgs>.InvokeMergedAndDispose(enterArgs).Forget();

```
