### PR TITLE
FEAT: 카드 '하나하나' 버려짐 이벤트 Args 추가

### DIFF
--- a/Assets/Scripts/Cards/Data/InStage/CardData.cs
+++ b/Assets/Scripts/Cards/Data/InStage/CardData.cs
@@ -24,6 +24,9 @@ namespace Cardevil.Cards.Data.InStage
         [SerializeField, VisibleOnly] private int length;
         [SerializeField, VisibleOnly] private SelectState<Direction> directionSelectState;
         [SerializeField, VisibleOnly] private DirectionFlag directionFlag;
+
+        public bool IsAttack => kind == CardKind.Attack;
+        public bool IsMove => kind == CardKind.Move;
         
         /// <summary>
         /// 스테이지 입장 전 상태로 초기화합니다.

--- a/Assets/Scripts/Cards/Data/InStage/CardDataValidateExtensions.cs
+++ b/Assets/Scripts/Cards/Data/InStage/CardDataValidateExtensions.cs
@@ -14,7 +14,7 @@ namespace Cardevil.Cards.Data.InStage
                 throw new InvalidOperationException($"잘못된 id: {data.Id}");
 
             // Attack 카드 검사
-            if (data.Kind == CardKind.Attack)
+            if (data.IsAttack)
             {
                 if (data.Color == CardColor.None)
                     throw new InvalidOperationException("Color가 None입니다.");
@@ -25,7 +25,7 @@ namespace Cardevil.Cards.Data.InStage
             }
 
             // Move 카드 검사
-            if (data.Kind == CardKind.Move)
+            if (data.IsMove)
             {
                 if (data.Length < 1)
                     throw new InvalidOperationException("이동 길이가 1보다 작습니다.");

--- a/Assets/Scripts/Cards/Evaluations/EvaluationPresenter.cs
+++ b/Assets/Scripts/Cards/Evaluations/EvaluationPresenter.cs
@@ -102,11 +102,11 @@ namespace Cardevil.Cards.Evaluations
             var handRanking = HandRankingEvaluator.EvaluateHandRanking(sortedCards);
 
             List<CardData> attacks = sortedCards
-                .Where(c => c.Data.Kind == CardKind.Attack)
+                .Where(c => c.Data.IsAttack)
                 .Select(c => c.Data).ToList();
 
             List<CardData> moves = sortedCards
-                .Where(c => c.Data.Kind == CardKind.Move)
+                .Where(c => c.Data.IsMove)
                 .Select(c => c.Data).ToList();
 
             _resultBuilder = EvaluationResult.CreateBuilder()

--- a/Assets/Scripts/Cards/Evaluations/EvaluationSequenceFactory.cs
+++ b/Assets/Scripts/Cards/Evaluations/EvaluationSequenceFactory.cs
@@ -28,7 +28,7 @@ namespace Cardevil.Cards.Evaluations
             var attackCards = new List<Card>();
             var moveCards = new List<Card>();
             foreach (var c in selection)
-                (c.Data.Kind == CardKind.Attack ? attackCards : moveCards).Add(c);
+                (c.Data.IsAttack ? attackCards : moveCards).Add(c);
 
             // Move Only
             if (attackCards.Count == 0 && moveCards.Count > 0)

--- a/Assets/Scripts/Cards/Evaluations/HandRankingEvaluator.cs
+++ b/Assets/Scripts/Cards/Evaluations/HandRankingEvaluator.cs
@@ -31,7 +31,7 @@ namespace Cardevil.Cards.Evaluations
         {
             cardsInHandRanking = null;
             
-            var attackCards = selection.Where(c => c.Data.Kind == CardKind.Attack)
+            var attackCards = selection.Where(c => c.Data.IsAttack)
                 .ToList();
         
             if (attackCards.Count == 0)

--- a/Assets/Scripts/Cards/InStage/Model/CardsModel.cs
+++ b/Assets/Scripts/Cards/InStage/Model/CardsModel.cs
@@ -75,9 +75,9 @@ namespace Cardevil.Cards.InStage.Model
                 foreach (var card in _selection)
                 {
                     var data = card.Data;
-                    if (data.Kind == CardKind.Attack && data.NumberSelectState.FinalValue != null)
+                    if (data.IsAttack && data.NumberSelectState.FinalValue != null)
                         continue;
-                    if (data.Kind == CardKind.Move && data.DirectionSelectState.FinalValue != null)
+                    if (data.IsMove && data.DirectionSelectState.FinalValue != null)
                         continue;
 
                     return false;
@@ -318,7 +318,7 @@ namespace Cardevil.Cards.InStage.Model
         
         private static int MoveSelectTypeOrder(Card c)
         {
-            if (c.Data.Kind != CardKind.Move)
+            if (!c.Data.IsMove)
                 return int.MaxValue;
 
             return c.Data.DirectionSelectState.Selectables.Count;
@@ -326,7 +326,7 @@ namespace Cardevil.Cards.InStage.Model
         
         private static int DirectionOrder(Card c)
         {
-            if (c.Data.Kind != CardKind.Move)
+            if (!c.Data.IsMove)
                 return int.MaxValue;
             if (!c.Data.DirectionSelectState.FinalValue.HasValue)
                 return 5;
@@ -343,12 +343,12 @@ namespace Cardevil.Cards.InStage.Model
 
         private static int ValueTypeOrder(Card c)
         {
-            return c.Data.Kind == CardKind.Move ? 0 : 1;
+            return c.Data.IsMove ? 0 : 1;
         }
         
         private static int NumberSelectTypeOrder(Card c)
         {
-            if (c.Data.Kind != CardKind.Attack)
+            if (!c.Data.IsAttack)
                 return int.MinValue;
 
             var n = c.Data.NumberSelectState;
@@ -359,7 +359,7 @@ namespace Cardevil.Cards.InStage.Model
 
         private static int NumberColorOrder(Card c)
         {
-            if (c.Data.Kind != CardKind.Attack)
+            if (!c.Data.IsAttack)
                 return int.MinValue;
 
             return (int)c.Data.Color;
@@ -367,7 +367,7 @@ namespace Cardevil.Cards.InStage.Model
 
         private static int NumberSelectedValueOrder(Card c)
         {
-            if (c.Data.Kind != CardKind.Attack)
+            if (!c.Data.IsAttack)
                 return int.MinValue;
 
             if (!c.Data.NumberSelectState.FinalValue.HasValue)

--- a/Assets/Scripts/Cards/InStage/Model/CardsModel.cs
+++ b/Assets/Scripts/Cards/InStage/Model/CardsModel.cs
@@ -1,7 +1,6 @@
 using Cardevil.Cards.Data;
 using Cardevil.Cards.Data.InStage;
 using System.Collections.Generic;
-using UnityEngine;
 using System.Linq;
 using System;
 using Random = UnityEngine.Random;

--- a/Assets/Scripts/Cards/InStage/Presenter/StageCardsPresenter.cs
+++ b/Assets/Scripts/Cards/InStage/Presenter/StageCardsPresenter.cs
@@ -448,21 +448,34 @@ namespace Cardevil.Cards.InStage.Presenter
         {
             await _evaluationPresenter.ExcuteSequenceAsync();
             await UniTask.Delay(TimeSpan.FromSeconds(.5f));
-            await DiscardAsync();
+            await DiscardAsync(false);
 
             cmp.TrySetResult();
         }
-
-        private async UniTask DiscardAsync()
+        
+        /// <param name="discardOnly">
+        /// '사용하기'가 아닌, '버리기' 버튼으로 버리기가 실행됐나 여부.
+        /// </param>
+        private async UniTask DiscardAsync(bool discardOnly)
         {
             foreach (var card in _model.SortedSelection.Reverse())
             {
                 _model.TryGetIndex(card, out var index);
                 
+                if (discardOnly)
+                {
+                    var cardData = card.Data;
+                    var args = EachCardDiscardedArgs.Get(cardData);
+                    ExecEventBus<EachCardDiscardedArgs>.InvokeMergedAndDispose(args).Forget();
+                }
+                
                 UnwireCard(card);
                 _model.Discard(card);
                 _handChanged?.Invoke();
                 card.DoDiscard();
+
+
+                    
                 
                 await UniTask.Delay(TimeSpan.FromSeconds(_visualSetting.DiscardInterval));
             }
@@ -497,7 +510,7 @@ namespace Cardevil.Cards.InStage.Presenter
             _state.isSwapping = true;
             UpdateUI();
             
-            await DiscardAsync();
+            await DiscardAsync(true);
             await UniTask.Delay(TimeSpan.FromSeconds(_visualSetting.DiscardDrawInterval));
             await DrawAsync();
             

--- a/Assets/Scripts/Cards/InStage/View/CardValueSelectionView.cs
+++ b/Assets/Scripts/Cards/InStage/View/CardValueSelectionView.cs
@@ -254,12 +254,12 @@ namespace Cardevil.Cards.InStage.View
                 var visual = go.GetComponent<CardVisualValueSelectionView>();
                 visual.Selected += OnValueSelected;
 
-                if (data.Kind == CardKind.Attack)
+                if (data.IsAttack)
                 {
                     var num = data.NumberSelectState.Selectables[i].value;
                     visual.Init(CardScale, data.Color, num);
                 }
-                else if (data.Kind == CardKind.Move)
+                else if (!data.IsMove)
                 {
                     var dir = data.DirectionSelectState.Selectables[i].value;
                     visual.Init(CardScale, dir);

--- a/Assets/Scripts/Events/EventArgs/Events.cs
+++ b/Assets/Scripts/Events/EventArgs/Events.cs
@@ -241,6 +241,14 @@ namespace Cardevil.Events
     /// </summary>
     public class CardDiscardChangeArgs : ExecEventArgs<CardDiscardChangeArgs>
     {
+        public int OldDiscard { get; private set; }
+        public int NewDiscard { get; private set; }
+        
+        /// <summary>
+        /// 이벤트 진행으로 인해 수정된 카드 버리기 횟수. 최종적으로 해당 개수로 카드 버리기 횟수가 설정됨.
+        /// </summary>
+        public int ModifiedDiscard { get; set; }
+        
         public static CardDiscardChangeArgs Get(int currentDiscard, int newDiscard)
         {
             var args = Get();
@@ -253,14 +261,6 @@ namespace Cardevil.Events
             First = int.MinValue,
             Last = int.MaxValue
         }
-
-        public int OldDiscard { get; private set; }
-        public int NewDiscard { get; private set; }
-
-        /// <summary>
-        /// 이벤트 진행으로 인해 수정된 카드 버리기 횟수. 최종적으로 해당 개수로 카드 버리기 횟수가 설정됨.
-        /// </summary>
-        public int ModifiedDiscard { get; set; }
 
         private void Init(int currentDiscard, int newDiscard)
         {
@@ -275,6 +275,29 @@ namespace Cardevil.Events
             OldDiscard = 0;
             NewDiscard = 0;
             ModifiedDiscard = 0;
+        }
+    }
+
+    /// <summary>
+    /// 카드 '하나하나'가 버려지는 이벤트 인자.
+    /// </summary>
+    public class EachCardDiscardedArgs : ExecEventArgs<EachCardDiscardedArgs>
+    {
+        public CardData CardData { get; private set; }
+
+        public static EachCardDiscardedArgs Get(CardData cardData)
+        {
+            var args = Get();
+            args.Init(cardData);
+            return args;
+        }
+
+        private void Init(CardData cardData) => CardData = cardData;
+
+        public override void Clear()
+        {
+            base.Clear();
+            CardData = null;
         }
     }
 }


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 FEAT: 카드 '하나하나' 버려짐 이벤트 Args 추가

## 📑 개요
<!--
   목적, 변경사항, 사용법에 대한 간략한 설명
   스크린샷이 포함될 수 있습니다.
-->
@rlaeodbsdk 

**카드가 '하나하나' 버려질 때** 사용하는 이벤트 Args 추가.
CardData를 인자로 갖고 있음.
'버리기'를 눌러서 버려질 때만 발행됨.


---


## 📖사용 방법
<!--
  (Optional)
  다른 사람이 사용하지 않아도 되는 경우 없어도 됩니다.
-->

**1. 숫자(공격) 카드인가 확인:**
`args.CardData.IsAttack`

**2. 카드 숫자 확인:**
`args.CardData.numberSelectState.FinalValue`

---



