### PR TITLE
FEAT: 족보 데이터에 족보에 해당되는 카드도 함께 저장

### DIFF
--- a/Assets/Scripts/NewCard/InStage/HandRankData.cs
+++ b/Assets/Scripts/NewCard/InStage/HandRankData.cs
@@ -1,4 +1,6 @@
 using Cardevil.NewCard.Common.Core;
+using System;
+using System.Collections.Generic;
 
 namespace Cardevil.NewCard.InStage
 {
@@ -10,11 +12,23 @@ namespace Cardevil.NewCard.InStage
         /// 플러시 계열일 경우 대표색도 저장함.
         /// </summary>
         public CardColor CardColor { get; }
+        public IReadOnlyList<ICardState> RankedCards { get; }
 
-        public HandRankData(HandRank handRank, CardColor cardColor = CardColor.None)
+        public HandRankData(
+            HandRank handRank,
+            IReadOnlyList<ICardState> rankedCards,
+            CardColor cardColor = CardColor.None)
         {
             HandRank = handRank;
             CardColor = cardColor;
+            RankedCards = rankedCards;
+        }
+
+        public HandRankData(HandRank handRank)
+        {
+            HandRank = handRank;
+            CardColor = CardColor.None;
+            RankedCards = Array.Empty<ICardState>();
         }
     }
 }

--- a/Assets/Scripts/NewCard/InStage/HandRankEvaluator.cs
+++ b/Assets/Scripts/NewCard/InStage/HandRankEvaluator.cs
@@ -10,46 +10,58 @@ namespace Cardevil.NewCard.InStage
         public static HandRankData GetHandRank(IReadOnlyList<ICardState> selection)
         {
             if (selection == null || selection.Count == 0) return new HandRankData(HandRank.None);
-            
+
             var attacks = selection
                 .Where(c => c.IsAttack)
                 .ToArray();
-            
+
             foreach (var card in attacks)
             {
                 if (!card.ValueSelected) return new HandRankData(HandRank.None);
             }
-            
-            Debug.Assert(attacks.All(card => card.Colors.Current.HasValue), "One or more cards' colors are null.");
-            Debug.Assert(attacks.All(card => card.Numbers.Current.HasValue), "One or more cards' numbers are null.");
+
+            Debug.Assert(attacks.All(card => card.Colors.Current.HasValue));
+            Debug.Assert(attacks.All(card => card.Numbers.Current.HasValue));
 
             var info = new HandInfo(attacks);
 
             if (info.IsFlush && info.IsFourCard)
-                return new HandRankData(HandRank.FourCardFlush, info.Color);
+                return new HandRankData(HandRank.FourCardFlush, info.All, info.Color);
 
             if (info.IsFlush && info.IsStraight)
-                return new HandRankData(HandRank.StraightFlush, info.Color);
+                return new HandRankData(HandRank.StraightFlush, info.All, info.Color);
 
             if (info.IsFlush && info.PairCount == 2)
-                return new HandRankData(HandRank.TwoPairFlush, info.Color);
+                return new HandRankData(HandRank.TwoPairFlush, info.All, info.Color);
 
             if (info.IsFourCard)
-                return new HandRankData(HandRank.FourCard);
+                return new HandRankData(HandRank.FourCard, info.All);
 
             if (info.IsStraight)
-                return new HandRankData(HandRank.Straight);
+                return new HandRankData(HandRank.Straight, info.All);
 
             if (info.IsTriple)
-                return new HandRankData(HandRank.Triple);
+            {
+                var cards = info.Groups.First(g => g.Count() >= 3).ToArray();
+                return new HandRankData(HandRank.Triple, cards);
+            }
 
             if (info.PairCount == 2)
-                return new HandRankData(HandRank.TwoPair);
+            {
+                var cards = info.Groups.Where(g => g.Count() == 2).SelectMany(g => g).ToArray();
+                return new HandRankData(HandRank.TwoPair, cards);
+            }
 
             if (info.PairCount == 1)
-                return new HandRankData(HandRank.OnePair);
+            {
+                var cards = info.Groups.First(g => g.Count() == 2).ToArray();
+                return new HandRankData(HandRank.OnePair, cards);
+            }
 
-            return new HandRankData(HandRank.HighCard);
+            var highCard = info.All
+                .OrderByDescending(c => c.Numbers.Current!.Value)
+                .First();
+            return new HandRankData(HandRank.HighCard, new[] { highCard });
         }
         
         private readonly struct HandInfo
@@ -61,28 +73,29 @@ namespace Cardevil.NewCard.InStage
             public int PairCount { get; }
             public CardColor Color { get; }
 
+            // 카드 참조를 유지하는 그룹
+            public IReadOnlyList<IGrouping<int, ICardState>> Groups { get; }
+            public IReadOnlyList<ICardState> All { get; }
+
             public HandInfo(IReadOnlyList<ICardState> attacks)
             {
+                All = attacks;
                 int count = attacks.Count;
 
-                // flush
                 var firstColor = attacks[0].Colors.Current!.Value;
                 Color = firstColor;
                 IsFlush = count == 4 &&
                           attacks.All(c => c.Colors.Current!.Value == firstColor);
 
-                // 숫자 그룹
-                var groups = attacks
+                Groups = attacks
                     .GroupBy(c => c.Numbers.Current!.Value)
-                    .Select(g => g.Count())
                     .ToList();
 
-                IsFourCard = groups.Any(c => c >= 4);
-                IsTriple = groups.Any(c => c >= 3);
-                PairCount = groups.Count(c => c == 2);
+                IsFourCard = Groups.Any(g => g.Count() >= 4);
+                IsTriple = Groups.Any(g => g.Count() >= 3);
+                PairCount = Groups.Count(g => g.Count() == 2);
 
-                // straight
-                if (count == 4 && groups.Count == 4)
+                if (count == 4 && Groups.Count == 4)
                 {
                     var numbers = attacks.Select(c => c.Numbers.Current!.Value);
                     IsStraight = numbers.Max() - numbers.Min() == 3;

--- a/Assets/Test/Card/HandRankEvaluatorTests.cs
+++ b/Assets/Test/Card/HandRankEvaluatorTests.cs
@@ -327,5 +327,190 @@ namespace Cardevil.Test.Card
 
             Assert.AreEqual(HandRank.OnePair, result.HandRank);
         }
+
+        // ============================================================
+        // RankedCards 검증
+        // ============================================================
+
+        [Test]
+        public void RankedCards_None_IsEmpty()
+        {
+            var state = new CardSpec(1, CardType.Attack)
+                .AddElements(
+                    new BaseColorElement(CardColor.Red),
+                    SelectableNumberElement.Fixed(1)
+                )
+                .State;
+
+            var result = HandRankEvaluator.GetHandRank(new List<ICardState> { state });
+
+            Assert.AreEqual(HandRank.None, result.HandRank);
+            Assert.IsEmpty(result.RankedCards);
+        }
+
+        [Test]
+        public void RankedCards_HighCard_ContainsSingleCard()
+        {
+            var card = CreateAttackCard(1, CardColor.Red, 5);
+
+            var result = HandRankEvaluator.GetHandRank(new List<ICardState> { card });
+
+            Assert.AreEqual(HandRank.HighCard, result.HandRank);
+            Assert.AreEqual(1, result.RankedCards.Count);
+            CollectionAssert.Contains(result.RankedCards, card);
+        }
+
+        [Test]
+        public void RankedCards_HighCard_ContainsHighestAttackCards()
+        {
+            var a = CreateAttackCard(1, CardColor.Red, 1);
+            var b = CreateAttackCard(2, CardColor.Blue, 3);
+            var c = CreateAttackCard(3, CardColor.Green, 6);
+            var d = CreateAttackCard(4, CardColor.Black, 9);
+
+            var result = HandRankEvaluator.GetHandRank(new List<ICardState> { a, b, c, d });
+
+            Assert.AreEqual(HandRank.HighCard, result.HandRank);
+            Assert.AreEqual(1, result.RankedCards.Count);
+            CollectionAssert.AreEquivalent(new ICardState[] { d }, result.RankedCards);
+        }
+
+        [Test]
+        public void RankedCards_OnePair_ContainsOnlyPairedCards()
+        {
+            var pair1 = CreateAttackCard(1, CardColor.Red, 3);
+            var pair2 = CreateAttackCard(2, CardColor.Blue, 3);
+            var other = CreateAttackCard(3, CardColor.Green, 7);
+
+            var result = HandRankEvaluator.GetHandRank(new List<ICardState> { pair1, pair2, other });
+
+            Assert.AreEqual(HandRank.OnePair, result.HandRank);
+            Assert.AreEqual(2, result.RankedCards.Count);
+            CollectionAssert.Contains(result.RankedCards, pair1);
+            CollectionAssert.Contains(result.RankedCards, pair2);
+            CollectionAssert.DoesNotContain(result.RankedCards, other);
+        }
+
+        [Test]
+        public void RankedCards_TwoPair_ContainsAllPairedCards()
+        {
+            var a = CreateAttackCard(1, CardColor.Red, 3);
+            var b = CreateAttackCard(2, CardColor.Blue, 3);
+            var c = CreateAttackCard(3, CardColor.Green, 7);
+            var d = CreateAttackCard(4, CardColor.Black, 7);
+
+            var result = HandRankEvaluator.GetHandRank(new List<ICardState> { a, b, c, d });
+
+            Assert.AreEqual(HandRank.TwoPair, result.HandRank);
+            Assert.AreEqual(4, result.RankedCards.Count);
+            CollectionAssert.AreEquivalent(new ICardState[] { a, b, c, d }, result.RankedCards);
+        }
+
+        [Test]
+        public void RankedCards_Triple_ContainsOnlyTripleCards()
+        {
+            var t1 = CreateAttackCard(1, CardColor.Red, 5);
+            var t2 = CreateAttackCard(2, CardColor.Blue, 5);
+            var t3 = CreateAttackCard(3, CardColor.Green, 5);
+            var other = CreateAttackCard(4, CardColor.Black, 9);
+
+            var result = HandRankEvaluator.GetHandRank(new List<ICardState> { t1, t2, t3, other });
+
+            Assert.AreEqual(HandRank.Triple, result.HandRank);
+            Assert.AreEqual(3, result.RankedCards.Count);
+            CollectionAssert.Contains(result.RankedCards, t1);
+            CollectionAssert.Contains(result.RankedCards, t2);
+            CollectionAssert.Contains(result.RankedCards, t3);
+            CollectionAssert.DoesNotContain(result.RankedCards, other);
+        }
+
+        [Test]
+        public void RankedCards_Straight_ContainsAllCards()
+        {
+            var a = CreateAttackCard(1, CardColor.Red, 3);
+            var b = CreateAttackCard(2, CardColor.Blue, 4);
+            var c = CreateAttackCard(3, CardColor.Green, 5);
+            var d = CreateAttackCard(4, CardColor.Black, 6);
+
+            var result = HandRankEvaluator.GetHandRank(new List<ICardState> { a, b, c, d });
+
+            Assert.AreEqual(HandRank.Straight, result.HandRank);
+            Assert.AreEqual(4, result.RankedCards.Count);
+            CollectionAssert.AreEquivalent(new ICardState[] { a, b, c, d }, result.RankedCards);
+        }
+
+        [Test]
+        public void RankedCards_FourCard_ContainsAllCards()
+        {
+            var a = CreateAttackCard(1, CardColor.Red, 7);
+            var b = CreateAttackCard(2, CardColor.Blue, 7);
+            var c = CreateAttackCard(3, CardColor.Green, 7);
+            var d = CreateAttackCard(4, CardColor.Black, 7);
+
+            var result = HandRankEvaluator.GetHandRank(new List<ICardState> { a, b, c, d });
+
+            Assert.AreEqual(HandRank.FourCard, result.HandRank);
+            Assert.AreEqual(4, result.RankedCards.Count);
+            CollectionAssert.AreEquivalent(new ICardState[] { a, b, c, d }, result.RankedCards);
+        }
+
+        [Test]
+        public void RankedCards_TwoPairFlush_ContainsAllCards()
+        {
+            var a = CreateAttackCard(1, CardColor.Red, 3);
+            var b = CreateAttackCard(2, CardColor.Red, 3);
+            var c = CreateAttackCard(3, CardColor.Red, 7);
+            var d = CreateAttackCard(4, CardColor.Red, 7);
+
+            var result = HandRankEvaluator.GetHandRank(new List<ICardState> { a, b, c, d });
+
+            Assert.AreEqual(HandRank.TwoPairFlush, result.HandRank);
+            Assert.AreEqual(4, result.RankedCards.Count);
+            CollectionAssert.AreEquivalent(new ICardState[] { a, b, c, d }, result.RankedCards);
+        }
+
+        [Test]
+        public void RankedCards_StraightFlush_ContainsAllCards()
+        {
+            var a = CreateAttackCard(1, CardColor.Blue, 4);
+            var b = CreateAttackCard(2, CardColor.Blue, 5);
+            var c = CreateAttackCard(3, CardColor.Blue, 6);
+            var d = CreateAttackCard(4, CardColor.Blue, 7);
+
+            var result = HandRankEvaluator.GetHandRank(new List<ICardState> { a, b, c, d });
+
+            Assert.AreEqual(HandRank.StraightFlush, result.HandRank);
+            Assert.AreEqual(4, result.RankedCards.Count);
+            CollectionAssert.AreEquivalent(new ICardState[] { a, b, c, d }, result.RankedCards);
+        }
+
+        [Test]
+        public void RankedCards_FourCardFlush_ContainsAllCards()
+        {
+            var a = CreateAttackCard(1, CardColor.Green, 9);
+            var b = CreateAttackCard(2, CardColor.Green, 9);
+            var c = CreateAttackCard(3, CardColor.Green, 9);
+            var d = CreateAttackCard(4, CardColor.Green, 9);
+
+            var result = HandRankEvaluator.GetHandRank(new List<ICardState> { a, b, c, d });
+
+            Assert.AreEqual(HandRank.FourCardFlush, result.HandRank);
+            Assert.AreEqual(4, result.RankedCards.Count);
+            CollectionAssert.AreEquivalent(new ICardState[] { a, b, c, d }, result.RankedCards);
+        }
+
+        [Test]
+        public void RankedCards_MoveCardsNotIncluded()
+        {
+            var attack1 = CreateAttackCard(1, CardColor.Red, 5);
+            var attack2 = CreateAttackCard(2, CardColor.Blue, 5);
+            var move = CreateMoveCard(3, Direction.Up);
+
+            var result = HandRankEvaluator.GetHandRank(new List<ICardState> { attack1, attack2, move });
+
+            Assert.AreEqual(HandRank.OnePair, result.HandRank);
+            Assert.AreEqual(2, result.RankedCards.Count);
+            CollectionAssert.DoesNotContain(result.RankedCards, move);
+        }
     }
 }


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 FEAT: 족보 데이터에 족보에 해당되는 카드도 함께 저장


<img width="859" height="728" alt="스크린샷 2026-02-14 오후 9 59 53" src="https://github.com/user-attachments/assets/ea0b3675-2462-45c6-a889-944908441f5f" />


---