### PR TITLE
REFACTOR: INewGameInitializable 분리

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -10,7 +10,7 @@ using Cardevil.Save;
 namespace Cardevil.Core
 {
     [System.Serializable]
-    public class GameManager : ISaveLoadRoot
+    public class GameManager : ISaveLoadRoot, INewGameInitializable
     {
         [Header("State")] 
         [field: SerializeField, VisibleOnly] public PlayerStatus PlayerStatus { get; private set; }

--- a/Assets/Scripts/Core/Root/WorldRoot.cs
+++ b/Assets/Scripts/Core/Root/WorldRoot.cs
@@ -98,10 +98,5 @@ namespace Cardevil.Core.Root
         {
            
         }
-
-        public void SetUpNewGame(GameSave save)
-        {
-            
-        }
     }
 }

--- a/Assets/Scripts/Save/ISaveLoadRoot.cs
+++ b/Assets/Scripts/Save/ISaveLoadRoot.cs
@@ -4,7 +4,7 @@ namespace Cardevil.Save
     /// 세이브/로드 루트 인터페이스.
     /// 세이브 로드 처리 및 신규 게임 초기화 기능 통합.
     /// </summary>
-    public interface ISaveLoadRoot : ISaveLoad, INewGameInitializable
+    public interface ISaveLoadRoot : ISaveLoad
     {
     }
 }

--- a/Assets/Scripts/Save/SaveLoadManager.cs
+++ b/Assets/Scripts/Save/SaveLoadManager.cs
@@ -74,7 +74,12 @@ namespace Cardevil.Save
         {
             var newSave = new GameSave(GetSlotFileName(slot), name);
             foreach (var saveRoot in _saveLoadRoots)
-                saveRoot.SetUpNewGame(newSave);
+            {
+                if (saveRoot is INewGameInitializable newGameInitializable)
+                {
+                    newGameInitializable.SetUpNewGame(newSave);
+                }
+            }
             
             _currentSlot = new Optional<SaveSlot>(slot);
             _currentSave = newSave;


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 REFACTOR: INewGameInitializable 분리

## 📑 개요
<!--
   목적, 변경사항, 사용법에 대한 간략한 설명
   스크린샷이 포함될 수 있습니다.
-->

ISaveLoadRoot와 INewGameInitializable를 분리했습니다.
일단 WorldRoot는 SetUpNewGame() 구현 안 합니다.

@machamy 형이 말한대로 `씬에 종속되서, 게임 초기화 시 초기화가 불가능한 매니저들`의 경우
필요할 때 새로 초기화하는게 나을 듯.

```C#
public void Init()
{
    var save = CardevilCore.Instance.SaveLoad.CurrentSave;
    if (save?.DungeonProgress != null && /*...*/)
    {
        // 세이브 로드

    }
    else
    {
        // 새 게임

        UI?.Initialize();
        /*...*/
     }
}
```

`Root가 필요한가, 등록이 필요한가` 등은 카드 시스템 완성 후 다시 보겠음.

---

