### PR TITLE
FEAT: 부트스트랩 버튼 추가

### DIFF
--- a/Assets/Scripts/Core/Bootstrap/Bootstrapper.cs
+++ b/Assets/Scripts/Core/Bootstrap/Bootstrapper.cs
@@ -16,6 +16,9 @@ namespace Cardevil.Core.Bootstrap
     /// </summary>
     public static class Bootstrapper
     {
+        public const string EditorStartScenePathKey = "Bootstrapper.EditorStartScenePath";
+        public const string EditorStartSceneNameKey = "Bootstrapper.EditorStartSceneName";
+
         /// <summary>
         /// 부트스트랩 진행률 변경 이벤트.
         /// 로드 완료 개수와 전체 개수 전달.

--- a/Assets/Scripts/Utils/MainToolbarStartBootstrapper.cs
+++ b/Assets/Scripts/Utils/MainToolbarStartBootstrapper.cs
@@ -1,0 +1,141 @@
+using Cardevil.Core.Bootstrap;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEditor.Toolbars;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Cardevil.Utils
+{
+    /// <summary>
+    /// 메인 툴바에서 부트스트래퍼 씬을 통해 게임을 시작할 수 있는 버튼을 제공합니다.
+    /// @machamy 코드.
+    /// </summary>
+    public static class MainToolbarStartBootstrapper
+    {
+        public const string BootstrapScenePath = "Assets/Scenes/BootstrapScene.unity";
+
+        const string LogPrefix = "[MainToolbarStartBootstrapper]";
+
+        // SessionState는 에디터 인스턴스별로 독립적으로 유지됩니다
+
+        const string EditorSessionCountKey = "MainToolbarStartBootstrapper.SessionCount";
+
+        [MainToolbarElement("Play/StartSceneFromBootstrapper", defaultDockPosition = MainToolbarDockPosition.Right)]
+        public static MainToolbarButton StartSceneFromBootstrapperButton()
+        {
+            string text;
+            Texture2D icon;
+            if (Application.isPlaying)
+            {
+                text = "현재 플레이중...";
+                icon = EditorGUIUtility.IconContent("sv_icon_dot12_pix16_gizmo").image as Texture2D;
+            }
+            else
+            {
+                text = "부트스트랩 하기";
+                icon = EditorGUIUtility.IconContent("sv_icon_dot11_pix16_gizmo").image as Texture2D;
+            }
+
+            var content = new MainToolbarContent(text, icon, "부트스트래퍼 씬에서 게임을 시작합니다.");
+            var button = new MainToolbarButton(content, OnButtonClick);
+
+            return button;
+        }
+
+        private static void OnButtonClick()
+        {
+            if (Application.isPlaying)
+            {
+                Debug.LogWarning($"{LogPrefix} 이미 Play 모드입니다.");
+                return;
+            }
+
+            if (!EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo())
+            {
+                Debug.Log($"{LogPrefix} 씬 저장이 취소되었습니다.");
+                return;
+            }
+
+            EditorPrefs.DeleteKey(Bootstrapper.EditorStartSceneNameKey);
+            EditorPrefs.DeleteKey(Bootstrapper.EditorStartScenePathKey);
+            EditorPrefs.DeleteKey(EditorSessionCountKey);
+
+            // 현재 씬 경로 저장
+            string currentScenePath = SceneManager.GetActiveScene().path;
+            string currentSceneName = SceneManager.GetActiveScene().name;
+
+            // 현재 씬이 부트스트랩이면 무시
+            if (currentScenePath == BootstrapScenePath)
+            {
+                Debug.LogWarning($"{LogPrefix} 현재 씬이 이미 부트스트래퍼 씬입니다. 시작만 합니다");
+                EditorApplication.EnterPlaymode();
+                return;
+            }
+
+
+            // Bootstrapper에도 전달
+            EditorPrefs.SetString(Bootstrapper.EditorStartScenePathKey, currentScenePath);
+            EditorPrefs.SetString(Bootstrapper.EditorStartSceneNameKey, currentSceneName);
+
+            EditorSceneManager.OpenScene(BootstrapScenePath);
+
+            EditorApplication.delayCall += () => { EditorApplication.EnterPlaymode(); };
+        }
+
+        [InitializeOnLoadMethod]
+        private static void Initialize()
+        {
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+        }
+
+        private static void OnPlayModeStateChanged(PlayModeStateChange state)
+        {
+            MainToolbar.Refresh("Play/StartSceneFromBootstrapper");
+
+            // SessionState 확인
+            string previousScenePath = EditorPrefs.GetString(Bootstrapper.EditorStartScenePathKey, null);
+
+            if (string.IsNullOrEmpty(previousScenePath))
+            {
+                return;
+            }
+
+            if (state == PlayModeStateChange.EnteredPlayMode)
+            {
+                Debug.Log($"{LogPrefix} Play 모드 진입 - 부트스트래퍼 씬에서 게임 시작됨.");
+                int sessionCount = EditorPrefs.GetInt(EditorSessionCountKey, 0);
+                sessionCount++;
+                EditorPrefs.SetInt(EditorSessionCountKey, sessionCount);
+                Debug.Log(
+                    $"{LogPrefix} {previousScenePath}({EditorPrefs.GetString(Bootstrapper.EditorStartSceneNameKey, "Unknown")}) 으로부터 시작됨. 세션 카운트: {sessionCount}");
+            }
+
+            // Play 모드가 완전히 종료된 후
+            if (state == PlayModeStateChange.EnteredEditMode)
+            {
+                var sceneAsset = AssetDatabase.LoadAssetAtPath<SceneAsset>(previousScenePath);
+
+                if (sceneAsset != null)
+                {
+                    EditorSceneManager.OpenScene(previousScenePath);
+                    Debug.Log($"{LogPrefix} 이전 씬으로 복귀: {previousScenePath}");
+                }
+
+                // EditorPrefs도 정리
+                int sessionCount = EditorPrefs.GetInt(EditorSessionCountKey, 0);
+                sessionCount = Mathf.Max(0, sessionCount - 1);
+                if (sessionCount <= 0)
+                {
+                    EditorPrefs.DeleteKey(Bootstrapper.EditorStartSceneNameKey);
+                    EditorPrefs.DeleteKey(Bootstrapper.EditorStartScenePathKey);
+                    Debug.Log($"{LogPrefix} 모든 세션 종료 - 이전 씬 정보 삭제");
+                }
+                else
+                {
+                    EditorPrefs.SetInt(EditorSessionCountKey, sessionCount);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Utils/MainToolbarStartBootstrapper.cs.meta
+++ b/Assets/Scripts/Utils/MainToolbarStartBootstrapper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5985ddb5b85c419db9713fa66f3e5b64
+timeCreated: 1772410627


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 FEAT: 부트스트랩 버튼 추가

## 📑 개요
<!--
   목적, 변경사항, 사용법에 대한 간략한 설명
   스크린샷이 포함될 수 있습니다.
-->

<img width="410" height="175" alt="스크린샷 2026-03-02 오전 9 23 52" src="https://github.com/user-attachments/assets/22a65b26-e539-4cf7-b609-a0fca70ea6de" />

부트스트랩 버튼을 추가했습니다.
해당 버튼을 누르면 부트스트래퍼 씬으로 이동해 시작합니다.

@machamy의 코드입니다.

---

