### PR TITLE
FIX: 이동 카드만 사용했을 때 데미지가 들어가던 버그 수정

### DIFF
--- a/Assets/Scripts/Card/InStage/Score/ScoreModel.cs
+++ b/Assets/Scripts/Card/InStage/Score/ScoreModel.cs
@@ -18,7 +18,7 @@ namespace Cardevil.Card.InStage.Score
         public float Score => score;
         public HandRank HandRank => handRankData.HandRank;
         public IReadOnlyList<IScoreOperator> ScoreOperators => scoreOperators;
-        public float HandRankScore => Random.Range(0, 100f);
+        public float HandRankScore => HandRank == HandRank.None ? 0f : Random.Range(0, 100f);
         
         public void SetScore(float value)
         {
@@ -35,6 +35,12 @@ namespace Cardevil.Card.InStage.Score
         {
             scoreOperators.Add(scoreOperator);
         }
+
+        public void ClearOperators()
+        {
+            scoreOperators.Clear();
+        }
+        
         public void Clear()
         {
             score = 0;

--- a/Assets/Scripts/Card/InStage/Score/ScorePresenter.cs
+++ b/Assets/Scripts/Card/InStage/Score/ScorePresenter.cs
@@ -2,7 +2,6 @@ using Cardevil.Core.Events.ExecEvent;
 using Cysharp.Threading.Tasks;
 using System;
 using UnityEngine;
-using Random = UnityEngine.Random;
 
 namespace Cardevil.Card.InStage.Score
 {
@@ -13,26 +12,12 @@ namespace Cardevil.Card.InStage.Score
         
         private readonly CardScoreView _view;
 
+        public float CurrentScore => model.Score;
+
         public ScorePresenter(CardScoreView view)
         {
             _view = view;
             _view.ClearScore();
-            
-            // Test 로직
-            async UniTask TestAsync()
-            {
-                const int testLoopCount = 10;
-                for (int i = 0; i < testLoopCount; i++)
-                {
-                    await AddOperatorAsync(new ScoreOperator
-                    {
-                        Type = ScoreOperatorType.Plus, Value = Random.Range(1f, 120f)
-                    });
-                }   
-            
-                ApplyOperatorsAsync().Forget();
-            }
-            // TestAsync().Forget();
         }
 
         public async UniTask AddOperatorAsync(IScoreOperator scoreOperator)
@@ -56,7 +41,7 @@ namespace Cardevil.Card.InStage.Score
             }
 
             var totalScore = model.Score;
-            model.Clear();
+            model.ClearOperators();
 
             return totalScore;
         } 

--- a/Assets/Scripts/Card/InStage/Score/Step/StepElementBuilder.cs
+++ b/Assets/Scripts/Card/InStage/Score/Step/StepElementBuilder.cs
@@ -45,12 +45,13 @@ namespace Cardevil.Card.InStage.Score.Step
             _providerRegistry = registry;
         }
 
-        public void BuildContext(IReadOnlyList<ICardState> cards, HandRankData handRankData)
+        public void BuildContext(IReadOnlyList<ICardState> cards, HandRankData handRankData, float handRankScore)
         {
             _context = new ScoreContext
             {
                 Cards = cards, 
-                HandRankData = handRankData
+                HandRankData = handRankData,
+                CurrentScore = handRankScore
             };
         }
 
@@ -58,7 +59,7 @@ namespace Cardevil.Card.InStage.Score.Step
 
         public IReadOnlyList<IStepElement> BuildSteps(ScoreStepType type)
         {
-            Debug.Assert(_context != null, "_context == null");
+            Debug.Assert(_context != null, "_context != null");
             
             return type switch
             {

--- a/Assets/Scripts/Card/InStage/_Core/StageCardCorePresenter.cs
+++ b/Assets/Scripts/Card/InStage/_Core/StageCardCorePresenter.cs
@@ -13,35 +13,35 @@ namespace Cardevil.Card.InStage
     public class StageCardCorePresenter : IDisposable
     {
         [SerializeField] private StageCardCoreModel model = new();
-        
-        private StepElementBuilder _elementBuilder;
+
+        private StepElementBuilder _stepBuilder;
         private UniTaskCompletionSource _playerInputWaiter;
-        
+
         // 외부 주입
         private HandBarPresenter _handBarPresenter;
         private ScorePresenter _scorePresenter;
         private StageCardCoreView _view;
-        
+
         public StageCardCorePresenter(
             IScoreProviderRegistry scoreProviderRegistry,
-            StageCardCoreView view, 
-            HandBarPresenter handBarPresenter, 
+            StageCardCoreView view,
+            HandBarPresenter handBarPresenter,
             ScorePresenter scorePresenter
-            )
+        )
         {
             _view = view;
             view.UseClicked += OnUseRequested;
             view.DiscardClicked += OnDiscardRequested;
-            
+
             view.SetAllButtonState(false);
-            
+
             _handBarPresenter = handBarPresenter;
             _scorePresenter = scorePresenter;
             handBarPresenter.HandBarStateChanged += OnHandBarStateChanged;
 
-            _elementBuilder = new StepElementBuilder(scoreProviderRegistry);
+            _stepBuilder = new StepElementBuilder(scoreProviderRegistry);
         }
-        
+
         public void Dispose()
         {
             _playerInputWaiter?.TrySetCanceled();
@@ -65,13 +65,21 @@ namespace Cardevil.Card.InStage
         /// </summary>
         public async UniTask WaitUntilPlayerInputAsync()
         {
+            _stepBuilder.ClearContext();
+            
             using (Interaction())
             {
                 _playerInputWaiter = new UniTaskCompletionSource();
-                
+
                 await _playerInputWaiter.Task;
                 _playerInputWaiter = null;
             }
+
+            _stepBuilder.BuildContext(
+                _handBarPresenter.SortedSelection,
+                _handBarPresenter.HandRankData,
+                _scorePresenter.CurrentScore
+            );
         }
 
         public async UniTask AddStepsAsync(params ScoreStepType[] types)
@@ -83,13 +91,13 @@ namespace Cardevil.Card.InStage
                 await AddStepAsync(type);
             }
         }
-        
+
         public async UniTask AddStepAsync(ScoreStepType type)
         {
-            var steps = _elementBuilder.BuildSteps(type);
+            var steps = _stepBuilder.BuildSteps(type);
             await InternalStepAsync(steps);
         }
-        
+
         /// <summary>
         /// 내부 발동 순서에 따라, 조건에 맞는 골드 획득 유물 처리.
         /// </summary>
@@ -98,7 +106,7 @@ namespace Cardevil.Card.InStage
             IReadOnlyList<IStepElement> steps = new List<IStepElement>();
             await InternalStepAsync(steps);
         }
-        
+
         /// <summary>
         /// 추가된 ScoreOperator들을 모두 계산함.
         /// </summary>
@@ -114,7 +122,7 @@ namespace Cardevil.Card.InStage
             model.Reroll(states);
             model.ShuffleDeck();
         }
-        
+
         private void OnHandBarStateChanged(in HandBarPresenter.SelectionState state)
         {
             _view.SetUseButtonState(state.CanUseSelection);
@@ -124,60 +132,61 @@ namespace Cardevil.Card.InStage
         private void OnUseRequested()
         {
             Debug.Assert(_handBarPresenter.CanUseSelection, "카드를 사용할 수 없지만 사용 버튼이 눌렸음.");
-            
+
             _view.SetAllButtonState(false);
-            
-            _elementBuilder.BuildContext(_handBarPresenter.SortedSelection, _handBarPresenter.HandRankData);
+
+            // _stepBuilder.BuildContext(_handBarPresenter.SortedSelection, _handBarPresenter.HandRankData);
             _playerInputWaiter?.TrySetResult();
         }
 
         private void OnDiscardRequested()
         {
             Debug.Assert(_handBarPresenter.CanDiscard, "카드를 버릴 수 없지만 버리기 버튼이 눌렸음.");
-            
+
             _view.SetAllButtonState(false);
 
             async UniTaskVoid DiscardAsync()
             {
                 _handBarPresenter.SetInputEnabled(false);
-                
+
                 var discardedStates = await _handBarPresenter.DiscardSelectionAsync();
                 model.Discard(discardedStates);
 
                 var states = model.Draw(discardedStates.Count);
                 await _handBarPresenter.DrawAsync(states);
-                
+
                 _handBarPresenter.SetInputEnabled(true);
             }
+
             DiscardAsync().Forget();
         }
 
         private async UniTask InternalStepAsync(IReadOnlyList<IStepElement> steps)
         {
             if (steps == null) return;
-            
+
             foreach (var step in steps)
             {
                 switch (step)
                 {
-                    case ScoreStepElement scoreStep: 
-                        if (scoreStep.Operator != null) 
+                    case ScoreStepElement scoreStep:
+                        if (scoreStep.Operator != null)
                             await _scorePresenter.AddOperatorAsync(scoreStep.Operator);
                         continue;
-                    
+
                     case MoveStepElement moveStep:
                         await ExecEventBus<PlayerMoveArgs>.InvokeMergedAndDispose(moveStep.Args);
                         await _handBarPresenter.DiscardAsync(moveStep.Card);
                         continue;
-                    
-                    case DiscardStepElement discardStep: 
+
+                    case DiscardStepElement discardStep:
                         await _handBarPresenter.DiscardAsync(discardStep.Card);
                         continue;
                 }
             }
         }
 
-        private InteractionScope Interaction() => new(_handBarPresenter);
+    private InteractionScope Interaction() => new(_handBarPresenter);
 
         private readonly struct InteractionScope : IDisposable
         {

--- a/Assets/Scripts/Card/InStage/_Core/StageCardCorePresenter.cs
+++ b/Assets/Scripts/Card/InStage/_Core/StageCardCorePresenter.cs
@@ -63,10 +63,10 @@ namespace Cardevil.Card.InStage
         /// 플레이어가 사용하기 버튼을 누를 때까지 대기.
         /// 이때 플레이어는 카드 선택, 값 변경, 순서변경 등을 수행할 수 있음.
         /// </summary>
-        public async UniTask WaitUntilPlayerInputAsync()
+        public async UniTask<bool> WaitUntilPlayerInputAsync()
         {
             _stepBuilder.ClearContext();
-            
+
             using (Interaction())
             {
                 _playerInputWaiter = new UniTaskCompletionSource();
@@ -74,12 +74,15 @@ namespace Cardevil.Card.InStage
                 await _playerInputWaiter.Task;
                 _playerInputWaiter = null;
             }
-
+            
             _stepBuilder.BuildContext(
                 _handBarPresenter.SortedSelection,
                 _handBarPresenter.HandRankData,
                 _scorePresenter.CurrentScore
             );
+            
+            bool isPlayerAttacking = _handBarPresenter.HandRankData.HandRank != HandRank.None;
+            return isPlayerAttacking;
         }
 
         public async UniTask AddStepsAsync(params ScoreStepType[] types)

--- a/Assets/Scripts/Gameplay/Turn/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/Turn/TurnManager.cs
@@ -85,35 +85,41 @@ namespace Cardevil.Gameplay.Turn
                 
                 await _currentEnemy.OnStartTurnAsync();
                 
-                await CardCore.WaitUntilPlayerInputAsync();
-
-                // 각 카드 연산
+                bool isPlayerAttacking = await CardCore.WaitUntilPlayerInputAsync();
+                
+                // 각 카드 처리
                 await CardCore.AddStepAsync(ScoreStepType.EachCard);
 
-                // 합 연산
-                await CardCore.AddStepAsync(ScoreStepType.PlusRelic);
-                await CardCore.AddStepAsync(ScoreStepType.PlusField);
-                await CardCore.AddStepAsync(ScoreStepType.PlusPlayerStatus);
-                await CardCore.ApplyScoreOperatorsAsync();
+                if (isPlayerAttacking)
+                {
+                    // 합 연산
+                    await CardCore.AddStepAsync(ScoreStepType.PlusRelic);
+                    await CardCore.AddStepAsync(ScoreStepType.PlusField);
+                    await CardCore.AddStepAsync(ScoreStepType.PlusPlayerStatus);
+                    await CardCore.ApplyScoreOperatorsAsync();
 
-                // 곱 연산, 골드 연산
-                await CardCore.AddStepAsync(ScoreStepType.MultiplyCardFinalDamage);
-                await CardCore.AddStepAsync(ScoreStepType.MultiplyRelic);
-                await CardCore.StepGoldRelicAsync();
-                await CardCore.AddStepAsync(ScoreStepType.MultiplyField);
-                await CardCore.AddStepAsync(ScoreStepType.MultiplyPlayerStatus);
-                await CardCore.ApplyScoreOperatorsAsync();
-                // TODO: 최종 데미지 출력하기 (근데 이게 뭔지 체크해야함)
+                    // 곱 연산, 골드 연산
+                    await CardCore.AddStepAsync(ScoreStepType.MultiplyCardFinalDamage);
+                    await CardCore.AddStepAsync(ScoreStepType.MultiplyRelic);
+                    await CardCore.StepGoldRelicAsync();
+                    await CardCore.AddStepAsync(ScoreStepType.MultiplyField);
+                    await CardCore.AddStepAsync(ScoreStepType.MultiplyPlayerStatus);
+                    await CardCore.ApplyScoreOperatorsAsync();
+                    // TODO: 최종 데미지 출력하기 (근데 이게 뭔지 체크해야함)
+                }
                 
                 await CardCore.DiscardSelectionAsync();
+
+                if (isPlayerAttacking)
+                {
+                    // 적 기믹 연산
+                    await CardCore.AddStepAsync(ScoreStepType.EnemyStatus);
+                    float finalScore = await CardCore.ApplyScoreOperatorsAsync();
+                    // TODO: 최종 데미지 출력하기 (근데 이게 뭔지 체크해야함)
                 
-                // 적 기믹 연산
-                await CardCore.AddStepAsync(ScoreStepType.EnemyStatus);
-                float finalScore = await CardCore.ApplyScoreOperatorsAsync();
-                // TODO: 최종 데미지 출력하기 (근데 이게 뭔지 체크해야함)
-                
-                await _player.AttackAsync(finalScore);
-                await _currentEnemy.OnTakeDamageAsync(finalScore);
+                    await _player.AttackAsync(finalScore);
+                    await _currentEnemy.OnTakeDamageAsync(finalScore);
+                }
 
                 var enemyContext = new EnemyContext
                 {

--- a/Assets/Scripts/Gameplay/Turn/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/Turn/TurnManager.cs
@@ -94,7 +94,7 @@ namespace Cardevil.Gameplay.Turn
                 await CardCore.AddStepAsync(ScoreStepType.PlusRelic);
                 await CardCore.AddStepAsync(ScoreStepType.PlusField);
                 await CardCore.AddStepAsync(ScoreStepType.PlusPlayerStatus);
-                float score0 = await CardCore.ApplyScoreOperatorsAsync();
+                await CardCore.ApplyScoreOperatorsAsync();
 
                 // 곱 연산, 골드 연산
                 await CardCore.AddStepAsync(ScoreStepType.MultiplyCardFinalDamage);
@@ -102,17 +102,15 @@ namespace Cardevil.Gameplay.Turn
                 await CardCore.StepGoldRelicAsync();
                 await CardCore.AddStepAsync(ScoreStepType.MultiplyField);
                 await CardCore.AddStepAsync(ScoreStepType.MultiplyPlayerStatus);
-                float score1 = await CardCore.ApplyScoreOperatorsAsync();
+                await CardCore.ApplyScoreOperatorsAsync();
                 // TODO: 최종 데미지 출력하기 (근데 이게 뭔지 체크해야함)
                 
                 await CardCore.DiscardSelectionAsync();
                 
                 // 적 기믹 연산
                 await CardCore.AddStepAsync(ScoreStepType.EnemyStatus);
-                float finalScore = score0 + score1 + await CardCore.ApplyScoreOperatorsAsync();
+                float finalScore = await CardCore.ApplyScoreOperatorsAsync();
                 // TODO: 최종 데미지 출력하기 (근데 이게 뭔지 체크해야함)
-                
-                // TODO: 임시로 고쳐놓음.
                 
                 await _player.AttackAsync(finalScore);
                 await _currentEnemy.OnTakeDamageAsync(finalScore);


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 FIX: 이동 카드만 사용했을 때 데미지가 들어가던 버그 수정

## 📑 개요
<!--
   목적, 변경사항, 사용법에 대한 간략한 설명
   스크린샷이 포함될 수 있습니다.
-->

이동 카드만 사용해도 데미지가 들어가던 문제를 수정했습니다.
이에 더해, 이동 카드만 사용한다면 공격 스탭엔 아예 진입하지 않습니다.

---
