### PR TITLE
REFACTOR : SceneLoader의 내부 구조 변경 및 로딩중 스테이지 안보이도록 수정

### DIFF
--- a/Assets/Prefabs/Dungeon/DungeonUI.prefab
+++ b/Assets/Prefabs/Dungeon/DungeonUI.prefab
@@ -184,6 +184,7 @@ MonoBehaviour:
   <SkippableTimelinePlayableDirector>k__BackingField: {fileID: 5115092642535421116}
   <TransitionToStagePlayableAsset>k__BackingField: {fileID: 11400000, guid: 531727917f55cc54087214c4afdf57a5, type: 2}
   <HandUpPlayableAsset>k__BackingField: {fileID: 11400000, guid: 28058358ef00fc24da584251259ddc25, type: 2}
+  chapterUIRectTransform: {fileID: 55388671689453536}
 --- !u!320 &4582846023241870710
 PlayableDirector:
   m_ObjectHideFlags: 0
@@ -193,7 +194,7 @@ PlayableDirector:
   m_GameObject: {fileID: 1310750160403465949}
   m_Enabled: 1
   serializedVersion: 3
-  m_PlayableAsset: {fileID: 11400000, guid: 28058358ef00fc24da584251259ddc25, type: 2}
+  m_PlayableAsset: {fileID: 11400000, guid: 531727917f55cc54087214c4afdf57a5, type: 2}
   m_InitialState: 0
   m_WrapMode: 2
   m_DirectorUpdateMode: 1
@@ -215,6 +216,16 @@ PlayableDirector:
     value: {fileID: 0}
   - key: {fileID: -8225272918172772315, guid: 28058358ef00fc24da584251259ddc25, type: 2}
     value: {fileID: 3888877301972129048}
+  - key: {fileID: -6926066952972113523, guid: c6b694ff97ce344178e5579e393c3b55, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 990281625074865129, guid: c6b694ff97ce344178e5579e393c3b55, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 4864578706283051154, guid: c6b694ff97ce344178e5579e393c3b55, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: -8004734514555262890, guid: c6b694ff97ce344178e5579e393c3b55, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: -6925956535159640983, guid: c6b694ff97ce344178e5579e393c3b55, type: 2}
+    value: {fileID: 0}
   m_ExposedReferences:
     m_References: []
 --- !u!114 &5115092642535421116

--- a/Assets/Scripts/Core/SceneManagement/SceneLoader.cs
+++ b/Assets/Scripts/Core/SceneManagement/SceneLoader.cs
@@ -1,6 +1,6 @@
-﻿using Cysharp.Threading.Tasks;
+﻿using Cardevil.Core.Utils;
+using Cysharp.Threading.Tasks;
 using System;
-using System.Threading;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -8,10 +8,24 @@ namespace Cardevil.Core.SceneManagement
 {
     public static class SceneLoader
     {
+        /// <summary>
+        /// SceneLoader를 통해 씬이 로드된 후에 발행. (Additive, Single 모두 발행)
+        /// </summary>
         public static event Action<Scenes, LoadSceneMode> SceneLoaded;
         
         /// <summary>
-        /// 씬 로드 끝까지 대기 후 <see cref="SceneLoaded"/> 발행.
+        /// SceneLoader를 통해 씬이 언로드된 후에 발행. <br/>
+        /// <b>주의:</b> LoadSceneMode.Single로 씬이 로드될 때는 이전 씬이 날아가지만 이 이벤트는 발행되지 않음.
+        /// </summary>
+        public static event Action<Scenes> SceneManuallyUnloaded;
+        
+        /// <summary>
+        /// 실제 Active 씬이 변경되었을 때만 발행. (이전 씬, 새 씬)
+        /// </summary>
+        public static event Action<Scenes, Scenes> ActiveSceneChanged;
+        
+        /// <summary>
+        /// 씬 로드 끝까지 대기.
         /// </summary>
         public static async UniTask LoadSceneAsync(Scenes scene, LoadSceneMode mode)
         {
@@ -20,43 +34,79 @@ namespace Cardevil.Core.SceneManagement
         }
 
         /// <summary>
-        /// AsyncOperation 반한. 호출자가 직접 제어.
+        /// AsyncOperation 반환.
+        /// allowSceneActivation이 false일경우 op는 IsDone이 true가 되지 않음.
         /// </summary>
-        /// <param name="activateOnLoad"><c>true</c>일 시, <c>completed</c>에서 <see cref="SceneLoaded"/> 발행.</param>
+        /// <param name="scene"></param>
+        /// <param name="mode"></param>
+        /// <param name="activateOnLoad">
+        /// true이면 로드 완료 시 Unity의 씬 활성화 단계를 바로 진행한다.
+        /// false이면 progress 0.9f에서 멈추며, 호출자가 op.allowSceneActivation = true로 완료 시점을 제어해야함
+        /// </param>
+        /// <returns></returns>
         public static AsyncOperation LoadSceneHandle(Scenes scene, LoadSceneMode mode, bool activateOnLoad = true)
         {
             var reference = SceneReference.Find(scene);
             var op = SceneManager.LoadSceneAsync(reference, mode);
             op.allowSceneActivation = activateOnLoad;
-
-            if (activateOnLoad)
-                op.completed += _ => SceneLoaded?.Invoke(scene, mode);
-
+            
+            Scenes prevActiveScene = SceneReference.Find(SceneManager.GetActiveScene().name).SceneEnum;
+            
+            
+            op.completed += _ =>
+            {
+                if (op.isDone)
+                {
+                    SceneLoaded?.Invoke(scene, mode);
+                    
+                    if (mode == LoadSceneMode.Single)
+                    {
+                        ActiveSceneChanged?.Invoke(prevActiveScene, scene);
+                    }
+                }
+                else
+                {
+                    Debug.LogError($"SceneLoader: Failed to load scene {scene}.");
+                }
+            };
+            
             return op;
         }
-        
+            
         public static async UniTask UnloadSceneAsync(Scenes scene)
         {
             var reference = SceneReference.Find(scene);
             await SceneManager.UnloadSceneAsync(reference);
+            SceneManuallyUnloaded?.Invoke(scene);
         }
 
-        public static void SetActiveScene(Scenes scene)
+        public static void SetActiveScene(Scenes scene, bool force = false)
         {
             var reference = SceneReference.Find(scene);
-            var s = SceneManager.GetSceneByName(reference);
-            SceneManager.SetActiveScene(s);
-        }
+            var targetScene = SceneManager.GetSceneByName(reference);
+            var currentActiveScene = SceneManager.GetActiveScene();
+            
+            if (!targetScene.IsValid() || !targetScene.isLoaded)
+            {
+                LogEx.LogError($"Cannot set active scene to '{scene}' because it is not loaded or does not exist.");
+                return;
+            }
+            
+            if (!force && currentActiveScene.name == targetScene.name)
+            {
+                return;
+            }
 
-        /// <summary>
-        /// 외부에서 <c>allowSceneActivation</c>을 <c>true</c>로 켠 후,
-        /// 씬 활성화 완료까지 기다렸다가 <see cref="SceneLoaded"/> 발행.
-        /// </summary>
-        public static async UniTask WaitSceneActivationAsync(Scenes scene, AsyncOperation op, LoadSceneMode mode,
-            CancellationToken ct)
-        {
-            await op.ToUniTask(cancellationToken: ct);
-            SceneLoaded?.Invoke(scene, mode);
+            Scenes prevActiveSceneEnum = SceneReference.Find(currentActiveScene.name).SceneEnum;
+            
+            if (SceneManager.SetActiveScene(targetScene))
+            {
+                ActiveSceneChanged?.Invoke(prevActiveSceneEnum, scene);
+            }
+            else
+            {
+                LogEx.LogError($"Failed to set active scene to '{scene}'.");
+            }
         }
     }
 }

--- a/Assets/Scripts/Core/SceneManagement/SceneReference.cs
+++ b/Assets/Scripts/Core/SceneManagement/SceneReference.cs
@@ -24,6 +24,19 @@ namespace Cardevil.Core.SceneManagement
             return null;
         }
         
+        public static SceneReference Find(string sceneName)
+        {
+            foreach (var kvp in sceneReferenceCache)
+            {
+                if (kvp.Value.SceneName == sceneName)
+                {
+                    return kvp.Value;
+                }
+            }
+            Debug.LogError($"SceneReference for scene name '{sceneName}' not found!");
+            return null;
+        }
+        
         public static void InitializeCache()
         {
             if (_initialized) return;
@@ -44,6 +57,7 @@ namespace Cardevil.Core.SceneManagement
         [SerializeField] private Scenes sceneEnum;
         [SerializeField, VisibleOnly] private string sceneName;
         
+        public Scenes SceneEnum => sceneEnum;
         public string SceneName => sceneName;
         
         

--- a/Assets/Scripts/Core/SceneManagement/Scenes.cs
+++ b/Assets/Scripts/Core/SceneManagement/Scenes.cs
@@ -5,7 +5,8 @@
         Bootstrap,
         Title,
         Stage,
-        World
+        World,
+        Shop
     }
     
     

--- a/Assets/Scripts/Gameplay/Dungeon/UI/DungeonTransition.cs
+++ b/Assets/Scripts/Gameplay/Dungeon/UI/DungeonTransition.cs
@@ -31,25 +31,9 @@ namespace Cardevil.Gameplay.Dungeon.UI
         
         private RectTransform _initialEnvironmentImagePosition;
         private RectTransform _initialPanelPosition;
-        // [Space(2f)]
-        // [Header("Legacy Settings (Unused)")]
-        // [Header("Animation Settings")]
-        // [Header("Phase 1: GNB Hide & Environment Zoom")]
-        // [SerializeField] private float gnbHideDuration = 0.5f;
-        // [SerializeField] private float zoomDuration = 0.5f;
-        // [SerializeField] private float environmentZoomScale = 1.2f;
-        // [Header("Phase 2: Panel Slide In")]
-        // [SerializeField] private float panelSlideDuration = 0.5f;
-        //
-        // [SerializeField] private Ease panelSlideEase = Ease.InOutSine;
-        // [Header("Phase 3: Pause")]
-        // [SerializeField] private float pauseDuration = 0.5f;
-        // [Header("Phase 4: Panel & Environment Zoom")]
-        // [SerializeField] private float finalZoomDuration = 0.5f;
-        // [SerializeField] private float finalPanelZoomScale = 100f;
-        // [SerializeField] private float finalEnvironmentZoomScale = 1.5f;
-        // [SerializeField] private Ease finalZoomEase = Ease.InOutSine;
-        // [SerializeField] private Ease finalPanelEase = Ease.InOutSine;
+        private RectTransform _initialChapterUIRectTransform;
+        [Header("UI Reference")]
+        [SerializeField] private RectTransform chapterUIRectTransform;
 
         private void Awake()
         {
@@ -58,6 +42,11 @@ namespace Cardevil.Gameplay.Dungeon.UI
             
             // _initialPanelPosition.gameObject.SetActive(false);
             // _initialEnvironmentImagePosition.gameObject.SetActive(false);
+            // _initialChapterUIRectTransform 
+            
+            
+            _initialChapterUIRectTransform = Instantiate(chapterUIRectTransform, chapterUIRectTransform.parent);
+            _initialChapterUIRectTransform.gameObject.SetActive(false);
             
             ExecEventBus<NodeEnteredEventArgs>.RegisterStatic(-1000, OnNodeEntered);
         }
@@ -93,6 +82,13 @@ namespace Cardevil.Gameplay.Dungeon.UI
             // PlayerSkipCheckTask(cancellationToken).Forget();
             
             await UniTask.WhenAny(durationTask, stopTask);
+        }
+
+        public void ResetChapterUITransform()
+        {
+            chapterUIRectTransform.anchoredPosition = _initialChapterUIRectTransform.anchoredPosition;
+            chapterUIRectTransform.localScale = _initialChapterUIRectTransform.localScale;
+            chapterUIRectTransform.rotation = _initialChapterUIRectTransform.rotation;
         }
 
         /// <summary>

--- a/Assets/Scripts/Gameplay/Root/WorldRoot.cs
+++ b/Assets/Scripts/Gameplay/Root/WorldRoot.cs
@@ -41,16 +41,20 @@ namespace Cardevil.Gameplay.Root
                 return;
             }
 
-            var op = SceneLoader.LoadSceneHandle(Scenes.Stage, LoadSceneMode.Additive);
-
+            var op = SceneLoader.LoadSceneHandle(Scenes.Stage, LoadSceneMode.Additive, activateOnLoad: false);
+            
             var loadReadyTask = UniTask.WaitUntil(() => op.progress >= .9f, cancellationToken: ct);
             var worldAnimTask = view.PlayStageEnterTransitionAsync(dungeon, ct);
 
             await UniTask.WhenAll(loadReadyTask, worldAnimTask);
-
+            
             op.allowSceneActivation = true;
-            await SceneLoader.WaitSceneActivationAsync(Scenes.Stage, op, LoadSceneMode.Additive, ct);
+            
+            await op;
+            
             SceneLoader.SetActiveScene(Scenes.Stage);
+            CameraManager.Instance.EnableSceneCameras(Scenes.Stage);
+            view.ResetChapterTransform(dungeon);
 
             view.HideMap(dungeon);
         }

--- a/Assets/Scripts/Gameplay/Root/WorldView.cs
+++ b/Assets/Scripts/Gameplay/Root/WorldView.cs
@@ -21,6 +21,17 @@ namespace Cardevil.Gameplay.Root
             dungeon.UI.gameObject.SetActive(false);
         }
 
+        public void ResetChapterTransform(DungeonManager dungeon)
+        {
+            if (dungeon?.Transition == null)
+            {
+                Debug.LogError("WorldView: Dungeon transition UI is not available while resetting chapter transform.");
+                return;
+            }
+
+            dungeon.Transition.ResetChapterUITransform();
+        }
+        
         public void PrepareMapForReturn(DungeonManager dungeon)
         {
             if (dungeon?.UI == null)


### PR DESCRIPTION
---
<!-- 
   양식 : 'PR타입 : 제목'
   타입은 대문자로 적어야한다. 예) FEAT/FIX/REFACTOR
-->
# 🚀 REFACTOR : SceneLoader의 내부 구조 변경 및 로딩중 스테이지 안보이도록 수정

## 📑 개요
<!--
   목적, 변경사항, 사용법에 대한 간략한 설명
   스크린샷이 포함될 수 있습니다.
-->

- SceneLoader의 내부 구조 변경
- 로딩중 스테이지 안보이도록 수정
---

## ✏️ 변경(추가) 사항

### 1) SceneLoader의 내부 구조 변경
씬로더에서 이벤트를 중복해서 부를 수 있는 구조를 변경했습니다. 또한 추가적인 씬 로딩 이벤트를 추가했습니다.

```C#
        /// <summary>
        /// SceneLoader를 통해 씬이 로드된 후에 발행. (Additive, Single 모두 발행)
        /// </summary>
        public static event Action<Scenes, LoadSceneMode> SceneLoaded;
        
        /// <summary>
        /// SceneLoader를 통해 씬이 언로드된 후에 발행. <br/>
        /// <b>주의:</b> LoadSceneMode.Single로 씬이 로드될 때는 이전 씬이 날아가지만 이 이벤트는 발행되지 않음.
        /// </summary>
        public static event Action<Scenes> SceneManuallyUnloaded;
        
        /// <summary>
        /// 실제 Active 씬이 변경되었을 때만 발행. (이전 씬, 새 씬)
        /// </summary>
        public static event Action<Scenes, Scenes> ActiveSceneChanged;
```

또한 `SceneReference` 에서 씬의 이름으로도 Find가능하도록 함수를 추가했습니다.


### 2) 로딩중 스테이지 안보이도록 수정
```C#
            var op = SceneLoader.LoadSceneHandle(Scenes.Stage, LoadSceneMode.Additive, activateOnLoad: false);
            
            var loadReadyTask = UniTask.WaitUntil(() => op.progress >= .9f, cancellationToken: ct);
            var worldAnimTask = view.PlayStageEnterTransitionAsync(dungeon, ct);

            await UniTask.WhenAll(loadReadyTask, worldAnimTask);
            
            op.allowSceneActivation = true;
            
            await op;
```
위 수정사항을 바탕으로 트랜지션이 끝난후 씬을 로드하도록 수정했습니다.



---

## 📖사용 방법
<!--
  (Optional)
  다른 사람이 사용하지 않아도 되는 경우 없어도 됩니다.
-->

op.progess가 0.9이상인경우는 모든 로드가 다 되었고 활성을 기다리는 상태입니다. 
op.allowSceneActivation = true; 를 하면 씬은 활성상태로 넘어갑니다

ActiveScene과 SceneActivation은 완전히 다른개념이니 주의!